### PR TITLE
Hook Unit Tests

### DIFF
--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -14,7 +14,7 @@ import { Sequelize } from 'sequelize';
  * @param {number} next_panel_set_id ID of panel set that hook links to
  * @returns response or error
  */
-const _createHookController = (sequelize: Sequelize) => async (position: number[], current_panel_id: number, next_panel_set_id: number) => {
+const _createHookController = (sequelize: Sequelize) => async (position: number[], current_panel_id: number, next_panel_set_id: number|null) => {
     try {
         const panel = await getPanel(sequelize)(current_panel_id);
         if (panel == null) throw new Error('no panel exists for given panel id');

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,8 +31,8 @@ export default (app: Express) => {
     app.get('/getUserByID', user.getUserByID);
 
     // Get from
-    app.get('/getPanelHooks', hook.getPanelHooks);
     app.get('/getPanelBasedOnPanelSetAndIndex', panel.getPanelBasedOnPanelSetAndIndex);
+    app.get('/getPanelHooks', hook.getPanelHooks);
     app.get('/getPanelsFromPanelSetID', panel.getPanelsFromPanelSetID);
     app.get('/getAllPanelSetsFromUser', panelSet.getAllPanelSetsFromUser);
 

--- a/src/services/hookService.ts
+++ b/src/services/hookService.ts
@@ -4,20 +4,20 @@ import { IHook } from '../models/hook.model';
 interface HookConfig {
     position: number[],
     current_panel_id: number,
-    next_panel_set_id: number
+    next_panel_set_id: number|null
 }
 
 interface HookCreateInfo {
     id: number,
     position: number[],
     current_panel_id: number,
-    next_panel_set_id: number
+    next_panel_set_id: number|null
 }
 
 interface HookGetInfo {
     position: number[],
     current_panel_id: number,
-    next_panel_set_id: number
+    next_panel_set_id: number|null
 }
 
 /**

--- a/src/tests/hook.test.ts
+++ b/src/tests/hook.test.ts
@@ -1,0 +1,186 @@
+import { _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController } from '../requestHandlers/hook';
+import * as hookService from '../services/hookService';
+import * as panelService from '../services/panelService';
+import * as panelSetService from '../services/panelSetService';
+import { Sequelize } from 'sequelize';
+jest.mock('../services/hookService');
+jest.mock('../services/panelService');
+jest.mock('../services/panelSetService');
+
+describe('_getHookController', () => {
+    let sequelizeMock: jest.Mocked<Sequelize>;
+
+    beforeEach(() => {
+        sequelizeMock = {} as jest.Mocked<Sequelize>;
+    });
+
+    test('If hook exists, it should be returned', async () => {
+        const hookData = {
+            position: [1,1],
+            current_panel_id: 1,
+            next_panel_set_id: 2
+        };
+
+        (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
+
+        const response = await _getHookController(sequelizeMock)(1);
+
+        expect(response).toEqual(hookData);
+    });
+
+    test('If the hook does not exists, it should return undefined', async () => {
+        (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.resolve(undefined));
+
+        const response = await _getHookController(sequelizeMock)(1);
+
+        expect(response).toBeUndefined();
+    });
+
+    test('If an error occurs, it should return the error', async () => {
+        (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+
+        const response = await _getHookController(sequelizeMock)(1);
+
+        expect(response).toBeInstanceOf(Error);
+    });
+});
+
+describe('_getPanelHooksController', () => {
+    let sequelizeMock: jest.Mocked<Sequelize>;
+
+    beforeEach(() => {
+        sequelizeMock = {} as jest.Mocked<Sequelize>;
+    });
+
+    test('If the panel has associated hooks, they should fill the array',
+        async () => {
+            const panelHookData = [
+                {
+                    position: [1,1],
+                    current_panel_id: 1,
+                    next_panel_set_id: 2
+                },
+                {
+                    position: [2,2],
+                    current_panel_id: 1,
+                    next_panel_set_id: 3
+                }
+            ];
+            const panelData = {
+                image:        '../phonyImage.png',
+                index:        0,
+                panel_set_id: 1
+            };
+    
+            (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
+            (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.resolve(panelHookData));
+
+            const response = await _getPanelHooksController(sequelizeMock)(1);
+
+            expect(response).toEqual(panelHookData);
+    });
+
+    test('If the panel has no associated hooks, return empty array', async () => {
+        const panelHookData = [] as number[];
+        const panelData = {
+            image:        '../phonyImage.png',
+            index:        0,
+            panel_set_id: 1
+        };
+
+        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
+        (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.resolve(panelHookData));
+
+        const response = await _getPanelHooksController(sequelizeMock)(1);
+
+        expect(response).toEqual([] as number[]);
+    });
+
+    test('If panel does not exist, a no panel exists error should be returned', async () => {
+        const error = new Error('no panel exists for given panel id');
+
+        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(null));
+        
+        const response = await _getPanelHooksController(sequelizeMock)(1);
+
+        expect(response).toEqual(error);
+    });
+
+    test('If an error occurs, the error should be returned', async () => {
+        (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+
+        const response = await _getPanelHooksController(sequelizeMock)(1);
+
+        expect(response).toBeInstanceOf(Error);
+    });
+});
+
+describe('_createHookController', () => {
+    let sequelizeMock: jest.Mocked<Sequelize>;
+
+    beforeEach(() => {
+        sequelizeMock = {} as jest.Mocked<Sequelize>;
+    });
+
+    test('If hook is created, hook info is returned', async () => {
+        const hookData = {
+            position: [1,1],
+            current_panel_id: 1,
+            next_panel_set_id: 2
+        };
+        const panelData = {
+            image:        '../phonyImage.png',
+            index:        0,
+            panel_set_id: 1
+        };
+        // const panelSetData = {
+        //     author_id: "abc123-efg456-hij789"
+        // };
+
+        // (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
+        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
+        (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
+
+        const response = await _createHookController(sequelizeMock)([1,1], 1, 2);
+
+        expect(response).toBe(hookData);
+    });
+
+    test('If hook (with null next panel set) is created, hook info is returned', async () => {
+        const hookData = {
+            position: [1,1],
+            current_panel_id: 1,
+            next_panel_set_id: null
+        };
+        const panelData = {
+            image:        '../phonyImage.png',
+            index:        0,
+            panel_set_id: 1
+        };
+
+        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
+        (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
+
+        const response = await _createHookController(sequelizeMock)([1,1], 1, null);
+
+        expect(response).toBe(hookData);
+    });
+
+    test('If current panel id does not exist, return that no panel exists', async () => {
+        const error = new Error('no panel exists for given panel id');
+
+        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(null));
+        
+        const response = await _createHookController(sequelizeMock)([1,1],1,2);
+
+        expect(response).toEqual(error);
+    });
+
+    test('If an error occurs, error should be returned', async () => {
+        (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+
+        const response = await _createHookController(sequelizeMock)([1,1],1,2);
+
+        expect(response).toBeInstanceOf(Error);
+    });
+})

--- a/src/tests/hook.test.ts
+++ b/src/tests/hook.test.ts
@@ -7,13 +7,9 @@ jest.mock('../services/hookService');
 jest.mock('../services/panelService');
 jest.mock('../services/panelSetService');
 
+const sequelizeMock = {} as jest.Mocked<Sequelize>;
+    
 describe('_getHookController', () => {
-    let sequelizeMock: jest.Mocked<Sequelize>;
-
-    beforeEach(() => {
-        sequelizeMock = {} as jest.Mocked<Sequelize>;
-    });
-
     test('If hook exists, it should be returned', async () => {
         const hookData = {
             position: [1,1],
@@ -46,12 +42,6 @@ describe('_getHookController', () => {
 });
 
 describe('_getPanelHooksController', () => {
-    let sequelizeMock: jest.Mocked<Sequelize>;
-
-    beforeEach(() => {
-        sequelizeMock = {} as jest.Mocked<Sequelize>;
-    });
-
     test('If the panel has associated hooks, they should fill the array',
         async () => {
             const panelHookData = [
@@ -116,12 +106,6 @@ describe('_getPanelHooksController', () => {
 });
 
 describe('_createHookController', () => {
-    let sequelizeMock: jest.Mocked<Sequelize>;
-
-    beforeEach(() => {
-        sequelizeMock = {} as jest.Mocked<Sequelize>;
-    });
-
     test('If hook is created, hook info is returned', async () => {
         const hookData = {
             position: [1,1],
@@ -182,12 +166,6 @@ describe('_createHookController', () => {
 });
 
 describe('_addSetToHookController', () => {
-    let sequelizeMock: jest.Mocked<Sequelize>;
-
-    beforeEach(() => {
-        sequelizeMock = {} as jest.Mocked<Sequelize>;
-    })
-
     test('If hook is successfully added, return it', async () => {
         const hookData = {
             position: [1,1],

--- a/src/tests/hook.test.ts
+++ b/src/tests/hook.test.ts
@@ -1,4 +1,6 @@
-import { _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController } from '../requestHandlers/hook';
+import {
+    _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController
+} from '../requestHandlers/hook';
 import * as hookService from '../services/hookService';
 import * as panelService from '../services/panelService';
 import * as panelSetService from '../services/panelSetService';
@@ -7,19 +9,19 @@ jest.mock('../services/hookService');
 jest.mock('../services/panelService');
 jest.mock('../services/panelSetService');
 
-const sequelizeMock = {} as jest.Mocked<Sequelize>;
-    
-describe('_getHookController', () => {
+const sequelizeMock = () => ({} as jest.Mocked<Sequelize>);
+
+describe('Get Hook Controller', () => {
     test('If hook exists, it should be returned', async () => {
         const hookData = {
-            position: [1,1],
-            current_panel_id: 1,
+            position:          [1, 1],
+            current_panel_id:  1,
             next_panel_set_id: 2
         };
 
         (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
-        const response = await _getHookController(sequelizeMock)(1);
+        const response = await _getHookController(sequelizeMock())(1);
 
         expect(response).toEqual(hookData);
     });
@@ -27,32 +29,33 @@ describe('_getHookController', () => {
     test('If the hook does not exists, it should return undefined', async () => {
         (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.resolve(undefined));
 
-        const response = await _getHookController(sequelizeMock)(1);
+        const response = await _getHookController(sequelizeMock())(1);
 
         expect(response).toBeUndefined();
     });
 
     test('If an error occurs, it should return the error', async () => {
-        (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+        (hookService.getHook as jest.Mock).mockReturnValue(() => { throw new Error('Error Message'); });
 
-        const response = await _getHookController(sequelizeMock)(1);
+        const response = await _getHookController(sequelizeMock())(1);
 
         expect(response).toBeInstanceOf(Error);
     });
 });
 
-describe('_getPanelHooksController', () => {
-    test('If the panel has associated hooks, they should fill the array',
+describe('Get Panel Hooks Controller', () => {
+    test(
+        'If the panel has associated hooks, they should fill the array',
         async () => {
             const panelHookData = [
                 {
-                    position: [1,1],
-                    current_panel_id: 1,
+                    position:          [1, 1],
+                    current_panel_id:  1,
                     next_panel_set_id: 2
                 },
                 {
-                    position: [2,2],
-                    current_panel_id: 1,
+                    position:          [2, 2],
+                    current_panel_id:  1,
                     next_panel_set_id: 3
                 }
             ];
@@ -61,14 +64,15 @@ describe('_getPanelHooksController', () => {
                 index:        0,
                 panel_set_id: 1
             };
-    
+
             (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
             (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.resolve(panelHookData));
 
-            const response = await _getPanelHooksController(sequelizeMock)(1);
+            const response = await _getPanelHooksController(sequelizeMock())(1);
 
             expect(response).toEqual(panelHookData);
-    });
+        }
+    );
 
     test('If the panel has no associated hooks, return empty array', async () => {
         const panelHookData = [] as number[];
@@ -81,7 +85,7 @@ describe('_getPanelHooksController', () => {
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
         (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.resolve(panelHookData));
 
-        const response = await _getPanelHooksController(sequelizeMock)(1);
+        const response = await _getPanelHooksController(sequelizeMock())(1);
 
         expect(response).toEqual([] as number[]);
     });
@@ -90,26 +94,26 @@ describe('_getPanelHooksController', () => {
         const error = new Error('no panel exists for given panel id');
 
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(null));
-        
-        const response = await _getPanelHooksController(sequelizeMock)(1);
+
+        const response = await _getPanelHooksController(sequelizeMock())(1);
 
         expect(response).toEqual(error);
     });
 
     test('If an error occurs, the error should be returned', async () => {
-        (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+        (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => { throw new Error('Error Message'); });
 
-        const response = await _getPanelHooksController(sequelizeMock)(1);
+        const response = await _getPanelHooksController(sequelizeMock())(1);
 
         expect(response).toBeInstanceOf(Error);
     });
 });
 
-describe('_createHookController', () => {
+describe('Create Hook Controller', () => {
     test('If hook is created, hook info is returned', async () => {
         const hookData = {
-            position: [1,1],
-            current_panel_id: 1,
+            position:          [1, 1],
+            current_panel_id:  1,
             next_panel_set_id: 2
         };
         const panelData = {
@@ -117,19 +121,19 @@ describe('_createHookController', () => {
             index:        0,
             panel_set_id: 1
         };
-        
+
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
         (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
-        const response = await _createHookController(sequelizeMock)([1,1], 1, 2);
+        const response = await _createHookController(sequelizeMock())([1, 1], 1, 2);
 
         expect(response).toBe(hookData);
     });
 
     test('If hook (with null next panel set) is created, hook info is returned', async () => {
         const hookData = {
-            position: [1,1],
-            current_panel_id: 1,
+            position:          [1, 1],
+            current_panel_id:  1,
             next_panel_set_id: null
         };
         const panelData = {
@@ -141,7 +145,7 @@ describe('_createHookController', () => {
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
         (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
-        const response = await _createHookController(sequelizeMock)([1,1], 1, null);
+        const response = await _createHookController(sequelizeMock())([1, 1], 1, null);
 
         expect(response).toBe(hookData);
     });
@@ -150,36 +154,34 @@ describe('_createHookController', () => {
         const error = new Error('no panel exists for given panel id');
 
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(null));
-        
-        const response = await _createHookController(sequelizeMock)([1,1],1,2);
+
+        const response = await _createHookController(sequelizeMock())([1, 1], 1, 2);
 
         expect(response).toEqual(error);
     });
 
     test('If an error occurs, error should be returned', async () => {
-        (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.reject(new Error('Error Message')));
+        (hookService.createHook as jest.Mock).mockReturnValue(() => { throw new Error('Error Message'); });
 
-        const response = await _createHookController(sequelizeMock)([1,1],1,2);
+        const response = await _createHookController(sequelizeMock())([1, 1], 1, 2);
 
         expect(response).toBeInstanceOf(Error);
     });
 });
 
-describe('_addSetToHookController', () => {
+describe('Add Set To Hook Controller', () => {
     test('If hook is successfully added, return it', async () => {
         const hookData = {
-            position: [1,1],
-            current_panel_id: 1,
+            position:          [1, 1],
+            current_panel_id:  1,
             next_panel_set_id: 2
         };
-        const panelSetData = {
-            author_id: "abc123-efg456-hij789"
-        };
+        const panelSetData = { author_id: 'abc123-efg456-hij789' };
 
         (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
         (hookService.addSetToHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
-        const response = await _addSetToHookController(sequelizeMock)(1,2);
+        const response = await _addSetToHookController(sequelizeMock())(1, 2);
 
         expect(response).toBe(hookData);
     });
@@ -189,20 +191,18 @@ describe('_addSetToHookController', () => {
 
         (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(null));
 
-        const response = await _addSetToHookController(sequelizeMock)(1,2);
+        const response = await _addSetToHookController(sequelizeMock())(1, 2);
 
         expect(response).toEqual(error);
     });
 
     test('If an error occurs, the error should be returned', async () => {
-        const panelSetData = {
-            author_id: "abc123-efg456-hij789"
-        };
+        const panelSetData = { author_id: 'abc123-efg456-hij789' };
 
         (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
-        (hookService.addSetToHook as jest.Mock).mockReturnValue(() => Promise.resolve(new Error('Error Messgage')));
+        (hookService.addSetToHook as jest.Mock).mockReturnValue(() => { throw new Error('Error Messgage'); });
 
-        const response = await _addSetToHookController(sequelizeMock)(1,2);
+        const response = await _addSetToHookController(sequelizeMock())(1, 2);
 
         expect(response).toBeInstanceOf(Error);
     });

--- a/src/tests/hook.test.ts
+++ b/src/tests/hook.test.ts
@@ -133,11 +133,7 @@ describe('_createHookController', () => {
             index:        0,
             panel_set_id: 1
         };
-        // const panelSetData = {
-        //     author_id: "abc123-efg456-hij789"
-        // };
-
-        // (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
+        
         (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
         (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
@@ -183,4 +179,53 @@ describe('_createHookController', () => {
 
         expect(response).toBeInstanceOf(Error);
     });
-})
+});
+
+describe('_addSetToHookController', () => {
+    let sequelizeMock: jest.Mocked<Sequelize>;
+
+    beforeEach(() => {
+        sequelizeMock = {} as jest.Mocked<Sequelize>;
+    })
+
+    test('If hook is successfully added, return it', async () => {
+        const hookData = {
+            position: [1,1],
+            current_panel_id: 1,
+            next_panel_set_id: 2
+        };
+        const panelSetData = {
+            author_id: "abc123-efg456-hij789"
+        };
+
+        (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
+        (hookService.addSetToHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
+
+        const response = await _addSetToHookController(sequelizeMock)(1,2);
+
+        expect(response).toBe(hookData);
+    });
+
+    test('If panel set does not exist, return panel set error', async () => {
+        const error = new Error('no panel_set exists for given panel_set_id');
+
+        (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(null));
+
+        const response = await _addSetToHookController(sequelizeMock)(1,2);
+
+        expect(response).toEqual(error);
+    });
+
+    test('If an error occurs, the error should be returned', async () => {
+        const panelSetData = {
+            author_id: "abc123-efg456-hij789"
+        };
+
+        (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve(panelSetData));
+        (hookService.addSetToHook as jest.Mock).mockReturnValue(() => Promise.resolve(new Error('Error Messgage')));
+
+        const response = await _addSetToHookController(sequelizeMock)(1,2);
+
+        expect(response).toBeInstanceOf(Error);
+    });
+});

--- a/src/tests/hook.test.ts
+++ b/src/tests/hook.test.ts
@@ -12,7 +12,7 @@ jest.mock('../services/panelSetService');
 const sequelizeMock = () => ({} as jest.Mocked<Sequelize>);
 
 describe('Get Hook Controller', () => {
-    test('If hook exists, it should be returned', async () => {
+    test('If service returns, then controller should return service value', async () => {
         const hookData = {
             position:          [1, 1],
             current_panel_id:  1,
@@ -24,14 +24,6 @@ describe('Get Hook Controller', () => {
         const response = await _getHookController(sequelizeMock())(1);
 
         expect(response).toEqual(hookData);
-    });
-
-    test('If the hook does not exists, it should return undefined', async () => {
-        (hookService.getHook as jest.Mock).mockReturnValue(() => Promise.resolve(undefined));
-
-        const response = await _getHookController(sequelizeMock())(1);
-
-        expect(response).toBeUndefined();
     });
 
     test('If an error occurs, it should return the error', async () => {
@@ -74,22 +66,6 @@ describe('Get Panel Hooks Controller', () => {
         }
     );
 
-    test('If the panel has no associated hooks, return empty array', async () => {
-        const panelHookData = [] as number[];
-        const panelData = {
-            image:        '../phonyImage.png',
-            index:        0,
-            panel_set_id: 1
-        };
-
-        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
-        (hookService.getPanelHooks as jest.Mock).mockReturnValue(() => Promise.resolve(panelHookData));
-
-        const response = await _getPanelHooksController(sequelizeMock())(1);
-
-        expect(response).toEqual([] as number[]);
-    });
-
     test('If panel does not exist, a no panel exists error should be returned', async () => {
         const error = new Error('no panel exists for given panel id');
 
@@ -126,26 +102,6 @@ describe('Create Hook Controller', () => {
         (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
 
         const response = await _createHookController(sequelizeMock())([1, 1], 1, 2);
-
-        expect(response).toBe(hookData);
-    });
-
-    test('If hook (with null next panel set) is created, hook info is returned', async () => {
-        const hookData = {
-            position:          [1, 1],
-            current_panel_id:  1,
-            next_panel_set_id: null
-        };
-        const panelData = {
-            image:        '../phonyImage.png',
-            index:        0,
-            panel_set_id: 1
-        };
-
-        (panelService.getPanel as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
-        (hookService.createHook as jest.Mock).mockReturnValue(() => Promise.resolve(hookData));
-
-        const response = await _createHookController(sequelizeMock())([1, 1], 1, null);
 
         expect(response).toBe(hookData);
     });


### PR DESCRIPTION
Added unit tests for hook controller functions

**[Hook Update]: Changed type of `next_panel_set_id` property from `number` to `number | null` since the property can be initialized with a `null` value**