### PR TITLE
Changed Hook Position to Save as JSON

### DIFF
--- a/src/models/hook.model.ts
+++ b/src/models/hook.model.ts
@@ -1,13 +1,14 @@
 import {
     CreationOptional, DataTypes, ForeignKey, InferAttributes, InferCreationAttributes, Model, Sequelize
 } from 'sequelize';
+import { Json } from 'sequelize/types/utils';
 
 /**
  * Hook model attributes
  */
 interface IHook extends Model<InferAttributes<IHook>, InferCreationAttributes<IHook>> {
     id: CreationOptional<number>,
-    position: number[];
+    position: Json;
     current_panel_id: ForeignKey<number>,
     next_panel_set_id: ForeignKey<number>
 }
@@ -27,7 +28,7 @@ const define = (sequelize: Sequelize): void => {
                 allowNull:     false
             },
             position: {
-                type:      DataTypes.ARRAY(DataTypes.FLOAT),
+                type:      DataTypes.JSONB,
                 allowNull: false
             },
             current_panel_id: {

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -5,16 +5,17 @@ import { getPanel } from '../services/panelService';
 import { getPanelSetByID } from '../services/panelSetService';
 import { sequelize } from '../database';
 import { Sequelize } from 'sequelize';
+import { Json } from 'sequelize/types/utils';
 
 
 /**
  * Create a hook
- * @param {number[]} position Hook position on panel
+ * @param {Json} position List of points for hook position
  * @param {number} current_panel_id ID of panel hook is on
  * @param {number} next_panel_set_id ID of panel set that hook links to
  * @returns response or error
  */
-const _createHookController = (sequelize: Sequelize) => async (position: number[], current_panel_id: number, next_panel_set_id: number|null) => {
+const _createHookController = (sequelize: Sequelize) => async (position: Json, current_panel_id: number, next_panel_set_id: number|null) => {
     try {
         const panel = await getPanel(sequelize)(current_panel_id);
         if (panel == null) throw new Error('no panel exists for given panel id');
@@ -36,7 +37,7 @@ const _createHookController = (sequelize: Sequelize) => async (position: number[
  * @returns 
  */
 const createHook = async (req: Request, res: Response): Promise<Response> => {
-    const position : number[] = req.body.position;
+    const position : Json = req.body.position;
     const current_panel_id : number = req.body.current_panel_id;
     const next_panel_set_id : number = req.body.next_panel_set_id;
 

--- a/src/services/hookService.ts
+++ b/src/services/hookService.ts
@@ -1,21 +1,22 @@
 import { Sequelize } from 'sequelize';
 import { IHook, IPanel } from '../models';
+import { Json } from 'sequelize/types/utils';
 
 interface HookConfig {
-    position: number[],
+    position: Json,
     current_panel_id: number,
     next_panel_set_id: number|null
 }
 
 interface HookCreateInfo {
     id: number,
-    position: number[],
+    position: Json,
     current_panel_id: number,
     next_panel_set_id: number|null
 }
 
 interface HookGetInfo {
-    position: number[],
+    position: Json,
     current_panel_id: number,
     next_panel_set_id: number|null
 }
@@ -48,8 +49,8 @@ const getHook = (sequelize : Sequelize) => async (id: number) => {
     // check that requested hook exists
     const hook = await sequelize.models.hook.findByPk(
         id,
-        {attributes: ['position', 'current_panel_id', 'next_panel_set_id']
-    }) as IHook;
+        { attributes: ['position', 'current_panel_id', 'next_panel_set_id'] }
+    ) as IHook;
     if (!hook) return undefined;
 
     // Return the hook's info
@@ -66,8 +67,9 @@ const getHook = (sequelize : Sequelize) => async (id: number) => {
  * @returns {HookGetInfo[]} Array of all hooks on given panel (empty array if none)
  */
 const getPanelHooks = (sequelize: Sequelize) => async (panel_id: number) => {
+
     // Find all hooks on requested panel 
-    const panel = await sequelize.models.panel.findByPk(panel_id, {include: sequelize.models.hook}) as IPanel;
+    const panel = await sequelize.models.panel.findByPk(panel_id, { include: sequelize.models.hook }) as IPanel;
     const hooks = panel.hooks as IHook[];
 
     // Parse hooks into usable objects
@@ -95,7 +97,7 @@ const addSetToHook = (sequelize: Sequelize) => async (hook_id: number, panel_set
     const hook = await sequelize.models.hook.findByPk(hook_id) as IHook;
     if (!hook) return undefined;
 
-    await hook.update({next_panel_set_id: panel_set_id});
+    await hook.update({ next_panel_set_id: panel_set_id });
 
     // Return the altered hook
     return {


### PR DESCRIPTION
### Description
Position attribute of the hook model now can save as a json, allowing for and array of coordinates to be provided as a parameter. 

### Example Query Body for `createHook`
``` 
{
    "position": [[1,1],[2,2],[3,3],[4,4],[5,5]],
    "current_panel_id": 1,
    "next_panel_set_id": null
} 
```

Note: There may be a more effective way to save this data. This solution works fine though