### PR TITLE
Rework get commands

### DIFF
--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -145,7 +145,7 @@
         }
       }
     },
-    "panel/{id}/hooks/": {
+    "/panel/{id}/hooks/": {
       "get": {
         "tags": [
           "hook"
@@ -262,6 +262,9 @@
     },
     "/panel_set/{id}/panels/": {
       "get": {
+        "tags": [
+          "panel"
+        ],
         "description": "",
         "parameters": [
           {
@@ -269,16 +272,53 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "panel_set_id",
+            "in": "query",
+            "type": "number"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "A panel",
+            "schema": {
+              "$ref": "#/definitions/panel"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "404": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "could not find panels under panelSet id ${panel_set_id}"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
     },
-    "/panel_set/{panel_set_id}/{index}": {
+    "/panel_set/{panel_set_id}/{index}/panel": {
       "get": {
         "tags": [
           "panel"
@@ -301,11 +341,6 @@
             "name": "id",
             "in": "query",
             "type": "number"
-          },
-          {
-            "name": "index",
-            "in": "query",
-            "type": "string"
           }
         ],
         "responses": {
@@ -403,59 +438,7 @@
         }
       }
     },
-    "/user/{id}/panels/": {
-      "get": {
-        "tags": [
-          "panel"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "panel_set_id",
-            "in": "query",
-            "type": "number"
-          },
-          {
-            "name": "id",
-            "in": "query",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A panel",
-            "schema": {
-              "$ref": "#/definitions/panel"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "404": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "could not find panels under panelSet id ${panel_set_id}"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/getAllPanelSetsFromUser": {
+    "/user/{id}/panel_sets/": {
       "get": {
         "tags": [
           "panel-set"
@@ -464,7 +447,8 @@
         "parameters": [
           {
             "name": "id",
-            "in": "query",
+            "in": "path",
+            "required": true,
             "type": "string"
           }
         ],
@@ -823,10 +807,70 @@
     },
     "/changeDisplayName": {
       "post": {
+        "tags": [
+          "user"
+        ],
         "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "newDisplayName": {
+                  "example": "any"
+                }
+              }
+            },
+            "description": "Change the display name for a user"
+          }
+        ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "display name successfully changed to Jane Smith"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "404": {
+            "description": "Response code is likely to change when we start using sessions to authenticate",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "could not find user with specified email/password"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -36,7 +36,7 @@
         }
       }
     },
-    "/hook/": {
+    "/hook/{id}": {
       "get": {
         "tags": [
           "hook"
@@ -46,20 +46,15 @@
           {
             "name": "id",
             "in": "query",
+            "required": true,
             "type": "number"
           }
         ],
         "responses": {
           "200": {
-            "description": "An array of hooks",
+            "description": "A hook",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/hook"
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/hook"
             }
           },
           "400": {
@@ -74,7 +69,7 @@
               "properties": {
                 "message": {
                   "type": "string",
-                  "example": "could not find hooks under panel with id ${id}"
+                  "example": "could not find hook with id ${req.body.id}"
                 }
               },
               "xml": {
@@ -85,72 +80,6 @@
           },
           "500": {
             "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/user/{id}": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/userResponse"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "404": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "User with id of \"${id}\" does not exist"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/user/{panelid}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "panelid",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
           }
         }
       }
@@ -202,6 +131,60 @@
                 "message": {
                   "type": "string",
                   "example": "could not find panel with id ${req.body.id}"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "panel/{id}/hooks/": {
+      "get": {
+        "tags": [
+          "hook"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of hooks",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/hook"
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "404": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "could not find hooks under panel with id ${id}"
                 }
               },
               "xml": {
@@ -277,7 +260,7 @@
         }
       }
     },
-    "/panel_set/panel/{id}": {
+    "/panel_set/{id}/panels/": {
       "get": {
         "description": "",
         "parameters": [
@@ -372,25 +355,25 @@
         }
       }
     },
-    "/hook/{id}": {
+    "/user/{id}/": {
       "get": {
         "tags": [
-          "hook"
+          "user"
         ],
         "description": "",
         "parameters": [
           {
             "name": "id",
-            "in": "query",
+            "in": "path",
             "required": true,
-            "type": "number"
+            "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "description": "A hook",
+            "description": "Success",
             "schema": {
-              "$ref": "#/definitions/hook"
+              "$ref": "#/definitions/userResponse"
             }
           },
           "400": {
@@ -405,7 +388,7 @@
               "properties": {
                 "message": {
                   "type": "string",
-                  "example": "could not find hook with id ${req.body.id}"
+                  "example": "User with id of \"${id}\" does not exist"
                 }
               },
               "xml": {
@@ -416,6 +399,24 @@
           },
           "500": {
             "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/user/{id}/panels/": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -457,7 +457,17 @@
     },
     "/getAllPanelSetsFromUser": {
       "get": {
+        "tags": [
+          "panel-set"
+        ],
         "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Get all panel sets from a user",

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -36,7 +36,7 @@
         }
       }
     },
-    "/getHook": {
+    "/hook/": {
       "get": {
         "tags": [
           "hook"
@@ -51,9 +51,15 @@
         ],
         "responses": {
           "200": {
-            "description": "A hook",
+            "description": "An array of hooks",
             "schema": {
-              "$ref": "#/definitions/hook"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/hook"
+              },
+              "xml": {
+                "name": "main"
+              }
             }
           },
           "400": {
@@ -68,7 +74,7 @@
               "properties": {
                 "message": {
                   "type": "string",
-                  "example": "could not find hook with id ${req.body.id}"
+                  "example": "could not find hooks under panel with id ${id}"
                 }
               },
               "xml": {
@@ -83,7 +89,73 @@
         }
       }
     },
-    "/getPanel": {
+    "/user/{id}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/userResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "404": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "User with id of \"${id}\" does not exist"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/user/{panelid}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "panelid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/panel/{id}": {
       "get": {
         "tags": [
           "panel"
@@ -93,6 +165,7 @@
           {
             "name": "id",
             "in": "query",
+            "required": true,
             "type": "number"
           }
         ],
@@ -143,7 +216,7 @@
         }
       }
     },
-    "/getPanelSetByID": {
+    "/panel_set/{id}": {
       "get": {
         "tags": [
           "panel-set"
@@ -153,6 +226,7 @@
           {
             "name": "id",
             "in": "query",
+            "required": true,
             "type": "number"
           }
         ],
@@ -203,54 +277,25 @@
         }
       }
     },
-    "/getUserByID": {
+    "/panel_set/panel/{id}": {
       "get": {
-        "tags": [
-          "user"
-        ],
         "description": "",
         "parameters": [
           {
             "name": "id",
-            "in": "query",
+            "in": "path",
+            "required": true,
             "type": "string"
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/userResponse"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "404": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "User with id of \"${id}\" does not exist"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
+          "default": {
+            "description": ""
           }
         }
       }
     },
-    "/getPanelBasedOnPanelSetAndIndex": {
+    "/panel_set/{panel_set_id}/{index}": {
       "get": {
         "tags": [
           "panel"
@@ -260,7 +305,14 @@
           {
             "name": "panel_set_id",
             "in": "query",
+            "required": true,
             "type": "number"
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "required": true,
+            "type": "string"
           },
           {
             "name": "id",
@@ -320,7 +372,7 @@
         }
       }
     },
-    "/getPanelHooks": {
+    "/hook/{id}": {
       "get": {
         "tags": [
           "hook"
@@ -330,20 +382,15 @@
           {
             "name": "id",
             "in": "query",
+            "required": true,
             "type": "number"
           }
         ],
         "responses": {
           "200": {
-            "description": "An array of hooks",
+            "description": "A hook",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/hook"
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/hook"
             }
           },
           "400": {
@@ -358,7 +405,7 @@
               "properties": {
                 "message": {
                   "type": "string",
-                  "example": "could not find hooks under panel with id ${id}"
+                  "example": "could not find hook with id ${req.body.id}"
                 }
               },
               "xml": {
@@ -369,26 +416,6 @@
           },
           "500": {
             "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/getPanelsFromPanelSetID": {
-      "get": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/getAllPanelSetsFromUser": {
-      "get": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
           }
         }
       }

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -81,7 +81,7 @@ const _getHookController = (sequelize: Sequelize) => async (id: number) => {
  * @returns 
  */
 const getHook = async (req: Request, res: Response): Promise<Response> => {
-    const id = Number(req.query.id);
+    const id = Number(req.params.id);
     const validArgs = assertArguments(
         { id },
         arg => !isNaN(arg),
@@ -91,7 +91,7 @@ const getHook = async (req: Request, res: Response): Promise<Response> => {
 
     const response = await _getHookController(sequelize)(id);
 
-    return sanitizeResponse(response, res, `could not find hook with id ${req.body.id}`);
+    return sanitizeResponse(response, res, `could not find hook with id ${id}`);
 
     /*
         #swagger.tags = ['hook']

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -136,7 +136,7 @@ const _getPanelHooksController = (sequelize: Sequelize) => async (id: number) =>
  * @returns 
  */
 const getPanelHooks = async (req: Request, res: Response): Promise<Response> => {
-    const id = Number(req.query.id);
+    const id = Number(req.params.id);
     const validArgs = assertArguments(
         { id },
         arg => !isNaN(arg),

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -139,8 +139,8 @@ const _getPanelBasedOnPanelSetAndIndexController = (sequelize : Sequelize) => as
 
 // the actual request for getting a panel
 const getPanelBasedOnPanelSetAndIndex = async (req: Request, res: Response): Promise<Response> => {
-    const panel_set_id = Number(req.query.panel_set_id);
-    const index = Number(req.query.index);
+    const panel_set_id = Number(req.params.panel_set_id);
+    const index = Number(req.params.index);
     const validArgs = assertArguments(
         { panel_set_id, index },
         arg => !isNaN(arg),

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -89,7 +89,7 @@ const _getPanelController = (sequelize : Sequelize) => async (id:number) => {
 
 // the actual request for getting a panel
 const getPanel = async (req: Request, res: Response): Promise<Response> => {
-    const id = Number(req.query.id);
+    const id = Number(req.params.id);
     const validArgs = assertArguments(
         { id },
         arg => !isNaN(arg),
@@ -192,7 +192,8 @@ const _getPanelsFromPanelSetIDController = (sequelize : Sequelize) => async (pan
 };
 
 const getPanelsFromPanelSetID = async (req: Request, res: Response): Promise<Response> => {
-    const panel_set_id = Number(req.query.id);
+    const panel_set_id = Number(req.params.id);
+    console.log(panel_set_id)
     const validArgs = assertArguments(
         { panel_set_id },
         arg => !isNaN(arg),

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -99,7 +99,7 @@ const getPanel = async (req: Request, res: Response): Promise<Response> => {
 
     const response = await _getPanelController(sequelize)(id);
 
-    return sanitizeResponse(response, res, `could not find panel with id ${req.body.id}`);
+    return sanitizeResponse(response, res, `could not find panel with id ${id}`);
 
     /*
         #swagger.tags = ['panel']
@@ -193,7 +193,6 @@ const _getPanelsFromPanelSetIDController = (sequelize : Sequelize) => async (pan
 
 const getPanelsFromPanelSetID = async (req: Request, res: Response): Promise<Response> => {
     const panel_set_id = Number(req.params.id);
-    console.log(panel_set_id)
     const validArgs = assertArguments(
         { panel_set_id },
         arg => !isNaN(arg),

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -28,7 +28,7 @@ const _createPanelSetController = (sequelize : Sequelize) => async (author_id: s
  * @returns 
  */
 const createPanelSet = async (request: Request, res: Response) : Promise<Response> => {
-    const author_id = request.body.author_id;
+    const author_id = (typeof request.body.author_id === 'string') ? request.body.author_id : '';
     const validArgs = assertArgumentsDefined({ author_id });
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _createPanelSetController(sequelize)(author_id);
@@ -62,7 +62,7 @@ const _getPanelSetByIDController = (sequelize: Sequelize) => async(id: number) =
 };
 
 const getPanelSetByID = async (request: Request, res: Response) : Promise<Response> => {
-    const id = Number(request.query.id);
+    const id = Number(request.params.id);
     const validArgs = assertArguments(
         { id },
         arg => !isNaN(arg),
@@ -108,7 +108,7 @@ const _getAllPanelSetsFromUserController = (sequelize: Sequelize) => async(id: s
 };
 
 const getAllPanelSetsFromUser = async(request: Request, res: Response) : Promise<Response> => {
-    const id = (typeof request.query.id === 'string') ? request.query.id : '';
+    const id = (typeof request.params.id === 'string') ? request.params.id : '';
     const validArgs = assertArguments(
         { id },
         arg => arg !== '',

--- a/src/requestHandlers/user.ts
+++ b/src/requestHandlers/user.ts
@@ -18,7 +18,7 @@ import { sequelize } from '../database';
  * @returns nulls if a user with the given id doesn't exist
  */
 const getUserByID = async (req: Request, res: Response): Promise<Response> => {
-    const id = (typeof req.query.id === 'string') ? req.query.id : '';
+    const id = (typeof req.params.id === 'string') ? req.params.id : '';
     const validArgs = assertArguments(
         { id },
         arg => arg !== '',

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,12 +12,12 @@ import * as utils from './requestHandlers/utils';
 
 export default (app: Express) => {
     app.get('/', help);
+    app.get('/user/.+', user.getUserByID); 
 
     // Get by ID
     app.get('/getHook', hook.getHook);
     app.get('/getPanel', panel.getPanel);
     app.get('/getPanelSetByID', panelSet.getPanelSetByID);
-    app.get('/getUserByID', user.getUserByID);
     app.get('/getPanelBasedOnPanelSetAndIndex', panel.getPanelBasedOnPanelSetAndIndex);
     app.get('/getPanelHooks', hook.getPanelHooks);
     app.get('/getPanelsFromPanelSetID', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,16 +12,14 @@ import * as utils from './requestHandlers/utils';
 
 export default (app: Express) => {
     app.get('/', help);
-    app.get('/user/.+', user.getUserByID); 
-
-    // Get by ID
-    app.get('/getHook', hook.getHook);
-    app.get('/getPanel', panel.getPanel);
-    app.get('/getPanelSetByID', panelSet.getPanelSetByID);
-    app.get('/getPanelBasedOnPanelSetAndIndex', panel.getPanelBasedOnPanelSetAndIndex);
-    app.get('/getPanelHooks', hook.getPanelHooks);
-    app.get('/getPanelsFromPanelSetID', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
-    app.get('/getAllPanelSetsFromUser', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
+    app.get('/hook/', hook.getPanelHooks);
+    app.get('/user/:id', user.getUserByID);
+    app.get('/user/panel:id', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
+    app.get('/panel/:id', panel.getPanel);
+    app.get('/panel_set/:id', panelSet.getPanelSetByID);
+    app.get('/panel_set/panel/:id', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
+    app.get('/panel_set/:panel_set_id/:index', panel.getPanelBasedOnPanelSetAndIndex);
+    app.get('/hook/:id', hook.getHook);
     app.get('*', utils.notFound);
 
     app.post('/createHook', hook.createHook);

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,12 +14,12 @@ export default (app: Express) => {
     app.get('/', help);
     app.get('/hook/:id', hook.getHook);
     app.get('/panel/:id', panel.getPanel);
-    app.get('panel/:id/hooks/', hook.getPanelHooks);
+    app.get('/panel/:id/hooks/', hook.getPanelHooks);
     app.get('/panel_set/:id', panelSet.getPanelSetByID);
     app.get('/panel_set/:id/panels/', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
-    app.get('/panel_set/:panel_set_id/:index', panel.getPanelBasedOnPanelSetAndIndex);
+    app.get('/panel_set/:panel_set_id/:index/panel', panel.getPanelBasedOnPanelSetAndIndex);
     app.get('/user/:id/', user.getUserByID);
-    app.get('/user/:id/panels/', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
+    app.get('/user/:id/panel_sets/', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
     app.get('*', utils.notFound);
 
     app.post('/createHook', hook.createHook);

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,14 +12,14 @@ import * as utils from './requestHandlers/utils';
 
 export default (app: Express) => {
     app.get('/', help);
-    app.get('/hook/', hook.getPanelHooks);
-    app.get('/user/:id', user.getUserByID);
-    app.get('/user/panel:id', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
-    app.get('/panel/:id', panel.getPanel);
-    app.get('/panel_set/:id', panelSet.getPanelSetByID);
-    app.get('/panel_set/panel/:id', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
-    app.get('/panel_set/:panel_set_id/:index', panel.getPanelBasedOnPanelSetAndIndex);
     app.get('/hook/:id', hook.getHook);
+    app.get('/panel/:id', panel.getPanel);
+    app.get('panel/:id/hooks/', hook.getPanelHooks);
+    app.get('/panel_set/:id', panelSet.getPanelSetByID);
+    app.get('/panel_set/:id/panels/', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
+    app.get('/panel_set/:panel_set_id/:index', panel.getPanelBasedOnPanelSetAndIndex);
+    app.get('/user/:id/', user.getUserByID);
+    app.get('/user/:id/panels/', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
     app.get('*', utils.notFound);
 
     app.post('/createHook', hook.createHook);


### PR DESCRIPTION
Refactored get commands so body is not used. queries are in the url.

`panel/1/hooks/` will return all of the hooks that are associated with the panel that has an id of 1
