### PR TITLE
Tree query

### DIFF
--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -345,11 +345,6 @@
             "name": "panel_set_id",
             "in": "query",
             "type": "number"
-          },
-          {
-            "name": "id",
-            "in": "query",
-            "type": "string"
           }
         ],
         "responses": {
@@ -622,6 +617,16 @@
           },
           "500": {
             "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/dumb": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -213,7 +213,7 @@
         }
       }
     },
-    "/panel/{id}/hooks/": {
+    "/panel/{id}/hooks": {
       "get": {
         "tags": [
           "hook"
@@ -328,7 +328,7 @@
         }
       }
     },
-    "/panel_set/{id}/panels/": {
+    "/panel_set/{id}/panels": {
       "get": {
         "tags": [
           "panel"
@@ -501,7 +501,7 @@
         }
       }
     },
-    "/user/{id}/panel_sets/": {
+    "/user/{id}/panel_sets": {
       "get": {
         "tags": [
           "panel-set"
@@ -617,6 +617,24 @@
           },
           "500": {
             "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/tree/{id}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -633,8 +633,8 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "400": {
+            "description": "Bad Request"
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -328,55 +328,20 @@
         }
       }
     },
-    "/panel_set/{id}/panels": {
+    "/panel_sets/{ids}/panels": {
       "get": {
-        "tags": [
-          "panel"
-        ],
         "description": "",
         "parameters": [
           {
-            "name": "id",
+            "name": "ids",
             "in": "path",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "panel_set_id",
-            "in": "query",
-            "type": "number"
           }
         ],
         "responses": {
-          "200": {
-            "description": "A panel",
-            "schema": {
-              "$ref": "#/definitions/panel"
-            }
-          },
           "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "404": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "could not find panels under panelSet id ${panel_set_id}"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
+            "description": "Bad Request"
           }
         }
       }

--- a/src/database.ts
+++ b/src/database.ts
@@ -45,15 +45,6 @@ const setup = async () => {
     sequelize.models.panel_set.hasOne(sequelize.models.hook, { foreignKey: 'next_panel_set_id' });
     sequelize.models.hook.belongsTo(sequelize.models.panel_set, { foreignKey: 'next_panel_set_id' });
 
-    sequelize.models.panel_set.hasMany(sequelize.models.panel_set, {
-        foreignKey: 'id',
-        as: 'hook_current_panel_set'
-      });
-      sequelize.models.panel_set.hasOne(sequelize.models.panel_set, {
-        foreignKey: 'id',
-        as: 'panel_set_origin_hook'
-      });
-
     // sync the table columns, create any tables that don't exist
     await sequelize.sync({ force: true });
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -45,6 +45,15 @@ const setup = async () => {
     sequelize.models.panel_set.hasOne(sequelize.models.hook, { foreignKey: 'next_panel_set_id' });
     sequelize.models.hook.belongsTo(sequelize.models.panel_set, { foreignKey: 'next_panel_set_id' });
 
+    sequelize.models.panel_set.hasMany(sequelize.models.panel_set, {
+        foreignKey: 'id',
+        as: 'hook_current_panel_set'
+      });
+      sequelize.models.panel_set.hasOne(sequelize.models.panel_set, {
+        foreignKey: 'id',
+        as: 'panel_set_origin_hook'
+      });
+
     // sync the table columns, create any tables that don't exist
     await sequelize.sync({ force: true });
 

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -28,7 +28,7 @@ const _createPanelController = (sequelize : Sequelize) => async (image: string, 
         }
         const panelIndex = panels.length;
 
-        // make new
+        // make new hook
         return await panelService.createPanel(sequelize)({
             image:        image,
             index:        panelIndex,
@@ -211,10 +211,10 @@ const _getPanelsFromPanelSetIDController = (sequelize : Sequelize) => async (pan
 };
 
 const getPanelsFromPanelSetID = async (req: Request, res: Response): Promise<Response> => {
-    const panel_set_id = Number(req.query.id);
+    const panel_set_id = req.params.id;
     const validArgs = assertArgumentsNumber({ panel_set_id });
     if (!validArgs.success) return res.status(400).json(validArgs);
-    const response = await _getPanelsFromPanelSetIDController(sequelize)(panel_set_id);
+    const response = await _getPanelsFromPanelSetIDController(sequelize)(Number(panel_set_id));
     return sanitizeResponse(response, res, `could not find panels under panelSet id ${panel_set_id}`);
 
     /*

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -225,7 +225,8 @@ const getPanelBasedOnPanelSetAndIndex = async (req: Request, res: Response): Pro
  */
 const _getPanelsFromPanelSetIDsController = (sequelize : Sequelize) => async (ids: number[]) => {
     try {
-        //remove duplicate ids
+
+        // remove duplicate ids
         const uniqueIds = [...new Set(ids)];
         return await panelService.getPanelsFromPanelSetIDs(sequelize)(uniqueIds);
     }
@@ -236,11 +237,11 @@ const _getPanelsFromPanelSetIDsController = (sequelize : Sequelize) => async (id
 
 const getPanelsFromPanelSetIDs = async (req: Request, res: Response): Promise<Response> => {
     const arr = req.params.ids.split('-') as [];
-    if(arr.some(a => isNaN(a)))
+    if (arr.some(a => isNaN(a)))
         return res.status(400).json(`"${arr.join(' ')}" contains items that are not numbers`);
     const response = await _getPanelsFromPanelSetIDsController(sequelize)(arr);
     return sanitizeResponse(response, res, `No panel set(s) with the id(s) ${arr.join(', ')} could be found`);
-}
+};
 
 export {
     _getPanelsFromPanelSetIDsController, getPanelsFromPanelSetIDs, createPanel, getPanelBasedOnPanelSetAndIndex, getPanel, _createPanelController, _getPanelController, _getPanelBasedOnPanelSetAndIndexController, updatePanel, _updatePanelController

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -221,5 +221,5 @@ const getPanelsFromPanelSetIDs = async (req: Request, res: Response): Promise<Re
 }
 
 export {
-    getPanelsFromPanelSetIDs, createPanel, getPanelBasedOnPanelSetAndIndex, getPanel, _createPanelController, _getPanelController, _getPanelBasedOnPanelSetAndIndexController, updatePanel, _updatePanelController
+    _getPanelsFromPanelSetIDsController, getPanelsFromPanelSetIDs, createPanel, getPanelBasedOnPanelSetAndIndex, getPanel, _createPanelController, _getPanelController, _getPanelBasedOnPanelSetAndIndexController, updatePanel, _updatePanelController
 };

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -1,16 +1,14 @@
 import { Request, Response } from 'express';
 import * as PanelSetService from '../services/panelSetService';
-import { Sequelize, Transaction, QueryTypes, DataTypes, ValidationError } from 'sequelize';
+import { Sequelize, Transaction, DataTypes } from 'sequelize';
 import {
     assertArgumentsDefined, assertArgumentsNumber, assertArgumentsString, sanitizeResponse
 } from './utils';
 import { sequelize } from '../database';
-import * as PanelService from '../services/panelService'
+import * as PanelService from '../services/panelService';
 import * as UserService from '../services/userService';
 import * as HookService from '../services/hookService';
-import { IHook, IPanel, IPanelSet, IUser } from '../models';
-import { _getPanelHooksController } from './hook';
-
+import { IPanel, IPanelSet, IUser } from '../models';
 
 /**
  * Create a new panel set
@@ -194,38 +192,39 @@ const getTree = async(request: Request, res: Response) : Promise<Response> => {
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _getTreeController(sequelize)(Number(panel_set_id)) as PanelSetNode[];
 
-    //! calling sanitizeResponse more than once throws an error unless it's a return statement
-    //! probably not the best way to check if an error is thrown
-    if(!Array.isArray(response)) {
+    // ! calling sanitizeResponse more than once throws an error unless it's a return statement
+    // ! probably not the best way to check if an error is thrown
+    if (!Array.isArray(response)) {
         return sanitizeResponse(response, res, `A panel set with an id of "${panel_set_id}" could not be found`);
     }
 
-    response.sort((a : PanelSetNode, b : PanelSetNode) => a.level - b.level)
+    response.sort((a : PanelSetNode, b : PanelSetNode) => a.level - b.level);
     const panel_sets = [] as PanelSetFrontEnd[];
-    for(const panel_set of response) {
+    for (const panel_set of response) {
         const children = response.filter(p => p.parent_panel_set_id == panel_set.panel_set_id);
         panel_sets.push({
             panel_set_id: panel_set.panel_set_id,
-            author_id: panel_set.author_id,
-            created_at: panel_set.created_at,
-            updated_at: panel_set.updated_at,
-            childrenIds: children.map(p => p.panel_set_id)
-        } as PanelSetFrontEnd)
+            author_id:    panel_set.author_id,
+            created_at:   panel_set.created_at,
+            updated_at:   panel_set.updated_at,
+            childrenIds:  children.map(p => p.panel_set_id)
+        } as PanelSetFrontEnd);
     }
-    return sanitizeResponse(panel_sets, res, 'Custom 404 error');;
-}
+    return sanitizeResponse(panel_sets, res, 'Custom 404 error');
+};
 
 const _getTreeController = (sequelize: Sequelize) => async(id: number) => {
     try {
         const response = await _getPanelSetByIDController(sequelize)(id);
-        //if an error or contains not a panelSet return
-        if(response instanceof Error) {
+
+        // if an error or contains not a panelSet return
+        if (response instanceof Error) {
             return response;
         }
-        
-        //? This isn't the best way to check if it's a panel set, but unsure of another way
-        if(response === null) {
-            return response
+
+        // ? This isn't the best way to check if it's a panel set, but unsure of another way
+        if (response === null) {
+            return response;
         }
         const root = response as IPanelSet;
         return await PanelSetService.getTree(sequelize)(root);
@@ -233,71 +232,69 @@ const _getTreeController = (sequelize: Sequelize) => async(id: number) => {
     catch (err) {
         return err;
     }
-}
+};
 
-//test methods so I don't have to run all of these queries every time I want to test something
+// test methods so I don't have to run all of these queries every time I want to test something
 const dumbDumb = async (request: Request, res: Response) => {
     const response = await _dumbDumbController(sequelize)();
     return sanitizeResponse(response, res, '');
-}
+};
 
 const _dumbDumbController = (sequelize: Sequelize) => async() => {
     try {
-        
-        //create a user
-        const user = await UserService.createUser(sequelize)(
-            {
-                password: "Password!",
-                email: "email@yaoo.com",
-                display_name: "display"
-            }
-        ) as IUser;
 
-        //create panel sets
+        // create a user
+        const user = await UserService.createUser(sequelize)({
+            password:     'Password!',
+            email:        'email@yaoo.com',
+            display_name: 'display'
+        }) as IUser;
+
+        // create panel sets
         const panel_set_count = 10;
         const panel_sets = [];
-        for(let i = 0; i < panel_set_count; i++) {
-            panel_sets.push(await PanelSetService.createPanelSet(sequelize)({
-                author_id: user.id
-            }) as IPanelSet);
+        for (let i = 0; i < panel_set_count; i++) {
+            panel_sets.push(await PanelSetService.createPanelSet(sequelize)({ author_id: user.id }) as IPanelSet);
         }
-        const panel_data = [1, 2, 3, 4, 4, 4]
-        //create 1 panel for each panel set
-        for(let i = 0; i < panel_data.length; i++){
+        const panel_data = [1, 2, 3, 4, 4, 4];
+
+        // create 1 panel for each panel set
+        for (let i = 0; i < panel_data.length; i++) {
             await PanelService.createPanel(sequelize)({
-                image: "",
-                index: 0,
+                image:        '',
+                index:        0,
                 panel_set_id: panel_data[i],
-                }) as IPanel
+            }) as IPanel;
         }
-        
+
         const hookConnection = [
-            { panel_id: 1, next_panel_set_id: 2 }, 
-            { panel_id: 1, next_panel_set_id: 3 }, 
-            { panel_id: 2, next_panel_set_id: 4 }, 
-            { panel_id: 4, next_panel_set_id: 5 }, 
-            { panel_id: 5, next_panel_set_id: 6 }, 
+            { panel_id: 1, next_panel_set_id: 2 },
+            { panel_id: 1, next_panel_set_id: 3 },
+            { panel_id: 2, next_panel_set_id: 4 },
+            { panel_id: 4, next_panel_set_id: 5 },
+            { panel_id: 5, next_panel_set_id: 6 },
             { panel_id: 6, next_panel_set_id: 7 }
-        ]
-        //add hooks
-        for(const hook of hookConnection) {
+        ];
+
+        // add hooks
+        for (const hook of hookConnection) {
             await HookService.createHook(sequelize)({
                 position: {
                     conditions: {},
-                    path: '',
-                    value: ''
+                    path:       '',
+                    value:      ''
                 },
                 current_panel_id:  hook.panel_id,
                 next_panel_set_id: hook.next_panel_set_id
-            })
+            });
         }
 
-        return {success: true};
-    } 
+        return { success: true };
+    }
     catch (err) {
         return err;
     }
-}
+};
 
 export {
     _getTreeController, getTree, dumbDumb, createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets, _createPanelSetController, _getAllPanelSetsFromUserController, _getPanelSetByIDController, _getAllTrunkSetsController

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -192,7 +192,7 @@ const getTree = async(request: Request, res: Response) : Promise<Response> => {
     const panel_set_id = request.params.id;
     const response = await _getTreeController(sequelize)(Number(panel_set_id)) as PanelSetNode[];
 
-    //! calling sanitizeResponse more than once throws an error
+    //! calling sanitizeResponse more than once throws an error unless it's a return statement
     //! probably not the best way to check if an error is thrown
     if(!Array.isArray(response)) {
         return sanitizeResponse(response, res);

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -196,6 +196,9 @@ const getTree = async(request: Request, res: Response) : Promise<Response> => {
     if(!Array.isArray(response)) {
         return sanitizeResponse(response, res);
     }
+
+    console.log(response)
+
     response.sort((a : PanelSetNode, b : PanelSetNode) => a.level - b.level)
     const panel_sets = [] as PanelSetFrontEnd[];
     for(const panel_set of response) {
@@ -216,12 +219,11 @@ const _getTreeController = (sequelize: Sequelize) => async(id: number) => {
         const response = await _getPanelSetByIDController(sequelize)(id);
         //if an error or contains not a panelSet return
         if(response instanceof Error) {
-            console.log('a')
             return response;
         }
         
         //? This isn't the best way to check if it's a panel set, but unsure of another way
-        if(!(response as any).author_id) {
+        if(response === null) {
             throw new Error(`A panel set with an id of "${id}" could not be found`)
         }
         const root = response as IPanelSet;

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -297,5 +297,5 @@ const _dumbDumbController = (sequelize: Sequelize) => async() => {
 }
 
 export {
-    getTree, dumbDumb, createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets, _createPanelSetController, _getAllPanelSetsFromUserController, _getPanelSetByIDController, _getAllTrunkSetsController
+    _getTreeController, getTree, dumbDumb, createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets, _createPanelSetController, _getAllPanelSetsFromUserController, _getPanelSetByIDController, _getAllTrunkSetsController
 };

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -73,7 +73,6 @@ const getPanelSetByID = async (request: Request, res: Response) : Promise<Respon
     const validArgs = assertArgumentsNumber({ id });
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _getPanelSetByIDController(sequelize)(id);
-    return res.status(400).json(response);
     return sanitizeResponse(response, res, `a panel with the id of "${id}" cannot be found`);
 
     // API documentation
@@ -217,6 +216,7 @@ const _getTreeController = (sequelize: Sequelize) => async(id: number) => {
         const response = await _getPanelSetByIDController(sequelize)(id);
         //if an error or contains not a panelSet return
         if(response instanceof Error) {
+            console.log('a')
             return response;
         }
         

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -168,6 +168,7 @@ const getAllTrunkSets = async(request: Request, res: Response) : Promise<Respons
     */
 };
 
+
 interface PanelSetNode {
     panel_set_id: number,
     parent_panel_set_id: number | null,

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -161,10 +161,10 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
 
     const hooks = data.hooks;
 
-    //ensure hooks exist
+    // ensure hooks exist
     if (!hooks) return res.status(400).json({ error: 'No hooks uploaded' });
 
-    if(!Array.isArray(hooks) || hooks.length < 3) return res.status(400).json({ error: 'At least 3 hooks need to be uploaded.' });
+    if (!Array.isArray(hooks) || hooks.length < 3) return res.status(400).json({ error: 'At least 3 hooks need to be uploaded.' });
 
     // validate
     for (let i = 0; i < hooks.length; i++) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,7 +28,7 @@ export default (app: Express) => {
     app.get('/panel/:id', panel.getPanel);
     app.get('/panel/:id/hooks', hook.getPanelHooks);
     app.get('/panel_set/:id', panelSet.getPanelSetByID);
-    app.get('/panel_set/:id/panels', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
+    app.get('/panel_sets/:ids/panels', panel.getPanelsFromPanelSetIDs); // documentation doesn't work for some reason
     app.get('/panel_set/:panel_set_id/:index/panel', panel.getPanelBasedOnPanelSetAndIndex);
     app.get('/user/:id/', user.getUserByID);
     app.get('/user/:id/panel_sets', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason

--- a/src/router.ts
+++ b/src/router.ts
@@ -40,7 +40,7 @@ export default (app: Express) => {
     app.get('/user/:id/', user.getUserByID);
     app.get('/user/:id/panel_sets', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
     app.get('/trunks', panelSet.getAllTrunkSets);
-    app.get('/tree/:id', panelSet.getTree)
+    app.get('/tree/:id', panelSet.getTree);
     app.get('/dumb', panelSet.dumbDumb);
 
     app.get('*', utils.notFound);

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,13 +26,14 @@ export default (app: Express) => {
 
     app.get('/hook/:id', hook.getHook);
     app.get('/panel/:id', panel.getPanel);
-    app.get('/panel/:id/hooks/', hook.getPanelHooks);
+    app.get('/panel/:id/hooks', hook.getPanelHooks);
     app.get('/panel_set/:id', panelSet.getPanelSetByID);
-    app.get('/panel_set/:id/panels/', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
+    app.get('/panel_set/:id/panels', panel.getPanelsFromPanelSetID); // documentation doesn't work for some reason
     app.get('/panel_set/:panel_set_id/:index/panel', panel.getPanelBasedOnPanelSetAndIndex);
     app.get('/user/:id/', user.getUserByID);
-    app.get('/user/:id/panel_sets/', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
+    app.get('/user/:id/panel_sets', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
     app.get('/trunks', panelSet.getAllTrunkSets);
+    app.get('/tree/:id', panelSet.getTree)
     app.get('/dumb', panelSet.dumbDumb);
 
     app.get('*', utils.notFound);

--- a/src/router.ts
+++ b/src/router.ts
@@ -33,6 +33,7 @@ export default (app: Express) => {
     app.get('/user/:id/', user.getUserByID);
     app.get('/user/:id/panel_sets/', panelSet.getAllPanelSetsFromUser); // documentation doesn't work for some reason
     app.get('/trunks', panelSet.getAllTrunkSets);
+    app.get('/dumb', panelSet.dumbDumb);
 
     app.get('*', utils.notFound);
 

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -1,6 +1,5 @@
 import { Sequelize, Op, Transaction } from 'sequelize';
 import { IPanel, IPanelSet } from '../models';
-import { sequelize } from '../database';
 
 interface PanelConfig {
     image: string,
@@ -95,19 +94,19 @@ const getPanelBasedOnPanelSetAndIndex = (sequelize : Sequelize) => async (index 
  */
 const getPanelsFromPanelSetIDs = (sequelize : Sequelize) => async (ids: number[]) => {
 
-    //get all of the panel_sets with the given ids
+    // get all of the panel_sets with the given ids
     const panel_sets = await sequelize.models.panel_set.findAll({
-            include: sequelize.models.panel,
-            where: {[Op.or]: ids.map(id => {return {id: id}})}
-      }) as IPanelSet[];
-      let panels = [] as IPanel[];
-      for(const panel_set of panel_sets) {
-        if(panel_set.panels?.length !== undefined && panel_set.panels.length > 0) {
+        include: sequelize.models.panel,
+        where:   { [Op.or]: ids.map(id => { return { id: id }; }) }
+    }) as IPanelSet[];
+    let panels = [] as IPanel[];
+    for (const panel_set of panel_sets) {
+        if (panel_set.panels?.length !== undefined && panel_set.panels.length > 0) {
             panels = panels.concat(panel_set.panels);
         }
-      }
+    }
 
-      return panels;
+    return panels;
 };
 
 

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -1,5 +1,6 @@
 import { Sequelize } from 'sequelize';
 import { IPanel, IPanelSet } from '../models';
+import { sequelize } from '../database';
 
 interface PanelConfig {
     image: string,

--- a/src/services/panelService.ts
+++ b/src/services/panelService.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from 'sequelize';
+import { Sequelize, Op } from 'sequelize';
 import { IPanel, IPanelSet } from '../models';
 import { sequelize } from '../database';
 
@@ -90,25 +90,27 @@ const getPanelBasedOnPanelSetAndIndex = (sequelize : Sequelize) => async (index 
 
 /**
  * Get all panels that are associated with a specific panelSet
- * @param {number} panel_set_id ID of panelSet
+ * @param {number[]} ids the ids of the panel set(s)
  * @returns {object[]} An array of objects with id, image, index properties
  */
-const getPanelsFromPanelSetID = (sequelize : Sequelize) => async (panel_set_id: number) => {
+const getPanelsFromPanelSetIDs = (sequelize : Sequelize) => async (ids: number[]) => {
 
-    // Find all panels on requested panelSet 
-    const panel_set = await sequelize.models.panel_set.findByPk(panel_set_id, { include: sequelize.models.panel }) as IPanelSet;
-    if (!panel_set) return [];
-    const panels = panel_set.panels as IPanel[];
+    //get all of the panel_sets with the given ids
+    const panel_sets = await sequelize.models.panel_set.findAll({
+            include: sequelize.models.panel,
+            where: {[Op.or]: ids.map(id => {return {id: id}})}
+      }) as IPanelSet[];
+      let panels = [] as IPanel[];
+      for(const panel_set of panel_sets) {
+        if(panel_set.panels?.length !== undefined && panel_set.panels.length > 0) {
+            panels = panels.concat(panel_set.panels);
+        }
+      }
 
-    // Map panels to keep only needed data
-    return panels.map((p) => ({
-        id:    p.id as number,
-        image: p.image,
-        index: p.index
-    }));
+      return panels;
 };
 
 
 export {
-    getPanelsFromPanelSetID, createPanel, getPanel, getPanelBasedOnPanelSetAndIndex, updatePanel
+    getPanelsFromPanelSetIDs, createPanel, getPanel, getPanelBasedOnPanelSetAndIndex, updatePanel
 };

--- a/src/services/panelSetService.ts
+++ b/src/services/panelSetService.ts
@@ -53,7 +53,61 @@ const getAllTrunkSets = async (sequelize: Sequelize) => {
 
     return trunks as IPanelSet[];
 };
+const getTree = (sequelize: Sequelize) => async (panel_set: IPanelSet) => {
+    const [results, metadata]  = await sequelize.query(`WITH RECURSIVE panel_set_tree AS (
+        -- Base case: start with the given panel_set_id
+        SELECT 
+            ps.id AS panel_set_id,
+            ps.author_id,
+            ps.created_at,
+            ps.updated_at,
+            0 AS level,
+            CAST(ps.id AS TEXT) AS path,
+            NULL::INTEGER AS parent_panel_set_id
+        FROM 
+            panel_sets ps
+        WHERE 
+            ps.id = ${panel_set.id}
+    
+        UNION ALL
+    
+        -- Recursive case: find direct child panel_sets
+        SELECT 
+            next_ps.id AS panel_set_id,
+            next_ps.author_id,
+            next_ps.created_at,
+            next_ps.updated_at,
+            pst.level + 1 AS level,
+            pst.path || '->' || CAST(next_ps.id AS TEXT) AS path,
+            pst.panel_set_id AS parent_panel_set_id
+        FROM 
+            panel_set_tree pst
+        JOIN 
+            panels p ON p.panel_set_id = pst.panel_set_id
+        JOIN 
+            hooks h ON h.current_panel_id = p.id
+        JOIN 
+            panel_sets next_ps ON next_ps.id = h.Next_panel_set_id
+        WHERE 
+            h.Next_panel_set_id IS NOT NULL
+    )
+    SELECT 
+        panel_set_id,
+        parent_panel_set_id,
+        author_id,
+        created_at,
+        updated_at,
+        level,
+        path
+    FROM 
+        panel_set_tree
+    ORDER BY 
+        path;`);
+
+    return results;
+    
+}
 
 export {
-    createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets
+    getTree, createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets
 };

--- a/src/services/panelSetService.ts
+++ b/src/services/panelSetService.ts
@@ -54,7 +54,7 @@ const getAllTrunkSets = async (sequelize: Sequelize) => {
     return trunks as IPanelSet[];
 };
 const getTree = (sequelize: Sequelize) => async (panel_set: IPanelSet) => {
-    const [results, metadata]  = await sequelize.query(`WITH RECURSIVE panel_set_tree AS (
+    const [results]  = await sequelize.query(`WITH RECURSIVE panel_set_tree AS (
         -- Base case: start with the given panel_set_id
         SELECT 
             ps.id AS panel_set_id,
@@ -105,8 +105,8 @@ const getTree = (sequelize: Sequelize) => async (panel_set: IPanelSet) => {
         path;`);
 
     return results;
-    
-}
+
+};
 
 export {
     getTree, createPanelSet, getPanelSetByID, getAllPanelSetsFromUser, getAllTrunkSets

--- a/src/tests/panel.test.ts
+++ b/src/tests/panel.test.ts
@@ -54,7 +54,7 @@ describe('_getPanelController', () => {
         expect(response).toBeInstanceOf(Error);
     });
 });
-describe('_getPanelsFromPanelSetIDController', () => {
+describe('_getPanelsFromPanelSetIDsController', () => {
     test('Should return what the service getPanelsFromPanelSetID returns', async () => {
         const panelData = [
             {
@@ -74,17 +74,17 @@ describe('_getPanelsFromPanelSetIDController', () => {
             }
         ];
 
-        (panelService.getPanelsFromPanelSetID as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
+        (panelService.getPanelsFromPanelSetIDs as jest.Mock).mockReturnValue(() => Promise.resolve(panelData));
 
-        const response = await panel._getPanelsFromPanelSetIDController(sequelizeMock)(1);
+        const response = await panel._getPanelsFromPanelSetIDsController(sequelizeMock)([1]);
 
         expect(response).toEqual(panelData);
     });
 
     test('If an error occurs, it should return the error', async () => {
-        (panelService.getPanelsFromPanelSetID as jest.Mock).mockReturnValue(() => Promise.resolve(new Error('Some error getting panels')));
+        (panelService.getPanelsFromPanelSetIDs as jest.Mock).mockReturnValue(() => Promise.resolve(new Error('Some error getting panels')));
 
-        const response = await panel._getPanelsFromPanelSetIDController(sequelizeMock)(1000);
+        const response = await panel._getPanelsFromPanelSetIDsController(sequelizeMock)([1000]);
         expect(response).toBeInstanceOf(Error);
     });
 });

--- a/src/tests/panelSet.test.ts
+++ b/src/tests/panelSet.test.ts
@@ -78,21 +78,21 @@ describe('Get tree', () => {
 
     test('if there is an error from _getPanelSetByIDController, return it', async () => {
         (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => { throw new Error('I am an error'); });
-        const response = await _getTreeController(sequelizeMock)(1); 
+        const response = await _getTreeController(sequelizeMock)(1);
         expect(response).toBeInstanceOf(Error);
-    })
+    });
 
     test('if the response from _getPanelSetByIDController is not a panel_set throw an error', async () => {
         (panelSetService.getPanelSetByID as jest.Mock).mockResolvedValue(null);
-        const response = await _getTreeController(sequelizeMock)(1); 
+        const response = await _getTreeController(sequelizeMock)(1);
         expect(response).toBeInstanceOf(Error);
-    })
+    });
 
     test('valid data should give results from getTree', async () => {
         const results = 'a';
-        (panelSetService.getPanelSetByID as jest.Mock).mockResolvedValue({author_id: '1'});
-        (panelSetService.getTree as jest.Mock).mockResolvedValue(results);
-        const response = await _getTreeController(sequelizeMock)(1); 
+        (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => Promise.resolve({ author_id: '1' }));
+        (panelSetService.getTree as jest.Mock).mockReturnValue(() => Promise.resolve(results));
+        const response = await _getTreeController(sequelizeMock)(1);
         expect(response).toEqual(results);
-    })
-})
+    });
+});

--- a/src/tests/panelSet.test.ts
+++ b/src/tests/panelSet.test.ts
@@ -74,10 +74,26 @@ describe('Get All Trunk Sets', () => {
     });
 
     describe('Get tree', () => {
-        test('if there is an error from _getPanelSetByIDController, return it', async () => {
-        (_getPanelSetByIDController as jest.Mock).mockRejectedValue(() => { throw new Error('I am an error'); });
-        const response = await _getTreeController(sequelizeMock)(1); 
+        let _getPanelSetByIDController = jest.fn();
 
+        test('if there is an error from _getPanelSetByIDController, return it', async () => {
+        (_getPanelSetByIDController as jest.Mock).mockResolvedValue( new Error('I am error') );
+        const response = await _getTreeController(sequelizeMock)(1); 
+        expect(response).toBeInstanceOf(Error);
+        })
+
+        test('if the response from _getPanelSetByIDController is not a panel_set throw an error', async () => {
+            (_getPanelSetByIDController as jest.Mock).mockResolvedValue(null);
+            const response = await _getTreeController(sequelizeMock)(1); 
+            expect(response).toBeInstanceOf(Error);
+        })
+
+        test('valid data should give results from getTree', async () => {
+            const results = 'a';
+            (_getPanelSetByIDController as jest.Mock).mockResolvedValue({author_id: '1'});
+            (panelSetService.getTree as jest.Mock).mockResolvedValue(results);
+            const response = await _getTreeController(sequelizeMock)(1); 
+            expect(response).toEqual(results);
         })
     })
 });

--- a/src/tests/panelSet.test.ts
+++ b/src/tests/panelSet.test.ts
@@ -1,5 +1,5 @@
 import {
-    _createPanelSetController, _getPanelSetByIDController, _getAllPanelSetsFromUserController, _getAllTrunkSetsController
+    _createPanelSetController, _getPanelSetByIDController, _getAllPanelSetsFromUserController, _getAllTrunkSetsController, _getTreeController
 } from '../requestHandlers/panelSet';
 import * as panelSetService from '../services/panelSetService';
 import * as userService from '../services/userService';
@@ -72,4 +72,12 @@ describe('Get All Trunk Sets', () => {
         const response = await _getAllTrunkSetsController(sequelizeMock);
         expect(response).toBeInstanceOf(Error);
     });
+
+    describe('Get tree', () => {
+        test('if there is an error from _getPanelSetByIDController, return it', async () => {
+        (_getPanelSetByIDController as jest.Mock).mockRejectedValue(() => { throw new Error('I am an error'); });
+        const response = await _getTreeController(sequelizeMock)(1); 
+
+        })
+    })
 });

--- a/src/tests/panelSet.test.ts
+++ b/src/tests/panelSet.test.ts
@@ -72,28 +72,27 @@ describe('Get All Trunk Sets', () => {
         const response = await _getAllTrunkSetsController(sequelizeMock);
         expect(response).toBeInstanceOf(Error);
     });
+});
 
-    describe('Get tree', () => {
-        let _getPanelSetByIDController = jest.fn();
+describe('Get tree', () => {
 
-        test('if there is an error from _getPanelSetByIDController, return it', async () => {
-        (_getPanelSetByIDController as jest.Mock).mockResolvedValue( new Error('I am error') );
+    test('if there is an error from _getPanelSetByIDController, return it', async () => {
+        (panelSetService.getPanelSetByID as jest.Mock).mockReturnValue(() => { throw new Error('I am an error'); });
         const response = await _getTreeController(sequelizeMock)(1); 
         expect(response).toBeInstanceOf(Error);
-        })
-
-        test('if the response from _getPanelSetByIDController is not a panel_set throw an error', async () => {
-            (_getPanelSetByIDController as jest.Mock).mockResolvedValue(null);
-            const response = await _getTreeController(sequelizeMock)(1); 
-            expect(response).toBeInstanceOf(Error);
-        })
-
-        test('valid data should give results from getTree', async () => {
-            const results = 'a';
-            (_getPanelSetByIDController as jest.Mock).mockResolvedValue({author_id: '1'});
-            (panelSetService.getTree as jest.Mock).mockResolvedValue(results);
-            const response = await _getTreeController(sequelizeMock)(1); 
-            expect(response).toEqual(results);
-        })
     })
-});
+
+    test('if the response from _getPanelSetByIDController is not a panel_set throw an error', async () => {
+        (panelSetService.getPanelSetByID as jest.Mock).mockResolvedValue(null);
+        const response = await _getTreeController(sequelizeMock)(1); 
+        expect(response).toBeInstanceOf(Error);
+    })
+
+    test('valid data should give results from getTree', async () => {
+        const results = 'a';
+        (panelSetService.getPanelSetByID as jest.Mock).mockResolvedValue({author_id: '1'});
+        (panelSetService.getTree as jest.Mock).mockResolvedValue(results);
+        const response = await _getTreeController(sequelizeMock)(1); 
+        expect(response).toEqual(results);
+    })
+})


### PR DESCRIPTION
- Returns a tree structure given a root `panel set`. Data is refactored in the handler before returned. We will be discussing this further in our meeting at 2, but it's possible that all other types of formatting will be done there as well. 
- Population of the DB can be done with the `dumb` query. This can be removed before the pr is merged
- Refactored `get panels from panel set id` to have multiple panel set ids
### Known issues
- Failing unit tests (there is a bug when trying to mock a service in a separate controller than what is being ran. Look at `valid data should give results from getTree`)
- Error handling works (meaning there are no crashes), but it is not descriptive. There are a lot of things that could possibly go wrong, and it's rather difficult to make it so it's understandable for the front end. I may need assistance with this. This may be a blocker for unit tests
- line 224 of `panelSet.ts` may need a refactor. Unsure of another way to do what I want