### PR TITLE
Create query to get hooks from panel set

### DIFF
--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -199,8 +199,8 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "400": {
+            "description": "Bad Request"
           }
         }
       }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -259,6 +259,24 @@
         }
       }
     },
+    "/panel_set/{id}/images": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
     "/panel_set/{id}": {
       "get": {
         "tags": [

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -187,6 +187,24 @@
         }
       }
     },
+    "/panel_sets/{id}/hooks": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/panel/{id}/hooks": {
       "get": {
         "tags": [

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -779,6 +779,16 @@
         }
       }
     },
+    "/uploadImages": {
+      "post": {
+        "description": "",
+        "responses": {
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
     "/createHook": {
       "post": {
         "tags": [

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -269,6 +269,30 @@ const _validateHookConnectionController = (sequelize : Sequelize) => async(next_
     }
     return { success: true };
 };
+
+const getAllHooksByPanelSetId = async (req: Request, res: Response): Promise<Response> => {
+    const id = req.params.id;
+    console.log(id);
+    const response = await _getAllHooksByPanelSetIdController(sequelize)(1);
+    return sanitizeResponse(response, res, `A panel set with a id of ${id} doesn't exist`);
+}
+
+/**
+ * @param panel_set_id the id of the panel set that is being checked for hooks
+ */
+const _getAllHooksByPanelSetIdController = (sequelize: Sequelize) => async(panel_set_id: number) =>  {
+    try {
+        //verify panel_set exists
+        const panelSet = await sequelize.models.panel_set.findByPk(panel_set_id, { include: sequelize.models.panel }) as IPanelSet;
+        if(panelSet === null) {
+            throw new Error(`A panel set with the id of ${panel_set_id} doesn't exist`);
+        }
+        return hookService.getAllHooksByPanelSetId(sequelize)(panel_set_id);
+    }
+    catch (err) {
+        return err;
+    }
+}
 export {
-    createHook, getHook, getPanelHooks, addSetToHook, _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController, _validateHookConnectionController
+    getAllHooksByPanelSetId, createHook, getHook, getPanelHooks, addSetToHook, _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController, _validateHookConnectionController, _getAllHooksByPanelSetIdController
 };

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -274,16 +274,17 @@ const getAllHooksByPanelSetId = async (req: Request, res: Response): Promise<Res
     const id = req.params.id;
     const response = await _getAllHooksByPanelSetIdController(sequelize)(Number(id));
     return sanitizeResponse(response, res, `A panel set with a id of ${id} doesn't exist`);
-}
+};
 
 /**
  * @param panel_set_id the id of the panel set that is being checked for hooks
  */
-const _getAllHooksByPanelSetIdController = (sequelize: Sequelize) => async(panel_set_id: number) =>  {
+const _getAllHooksByPanelSetIdController = (sequelize: Sequelize) => async(panel_set_id: number) => {
     try {
-        //verify panel_set exists
+
+        // verify panel_set exists
         const panelSet = await sequelize.models.panel_set.findByPk(panel_set_id, { include: sequelize.models.panel }) as IPanelSet;
-        if(panelSet === null) {
+        if (panelSet === null) {
             throw new Error(`A panel set with the id of ${panel_set_id} doesn't exist`);
         }
         return hookService.getAllHooksByPanelSetId(sequelize)(panel_set_id);
@@ -291,7 +292,7 @@ const _getAllHooksByPanelSetIdController = (sequelize: Sequelize) => async(panel
     catch (err) {
         return err;
     }
-}
+};
 export {
     getAllHooksByPanelSetId, createHook, getHook, getPanelHooks, addSetToHook, _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController, _validateHookConnectionController, _getAllHooksByPanelSetIdController
 };

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -272,7 +272,6 @@ const _validateHookConnectionController = (sequelize : Sequelize) => async(next_
 
 const getAllHooksByPanelSetId = async (req: Request, res: Response): Promise<Response> => {
     const id = req.params.id;
-    console.log(id);
     const response = await _getAllHooksByPanelSetIdController(sequelize)(1);
     return sanitizeResponse(response, res, `A panel set with a id of ${id} doesn't exist`);
 }

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -272,6 +272,8 @@ const _validateHookConnectionController = (sequelize : Sequelize) => async(next_
 
 const getAllHooksByPanelSetId = async (req: Request, res: Response): Promise<Response> => {
     const id = req.params.id;
+    const validArgs = assertArgumentsNumber({ id });
+    if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _getAllHooksByPanelSetIdController(sequelize)(Number(id));
     return sanitizeResponse(response, res, `A panel set with a id of ${id} doesn't exist`);
 };

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -272,7 +272,7 @@ const _validateHookConnectionController = (sequelize : Sequelize) => async(next_
 
 const getAllHooksByPanelSetId = async (req: Request, res: Response): Promise<Response> => {
     const id = req.params.id;
-    const response = await _getAllHooksByPanelSetIdController(sequelize)(1);
+    const response = await _getAllHooksByPanelSetIdController(sequelize)(Number(id));
     return sanitizeResponse(response, res, `A panel set with a id of ${id} doesn't exist`);
 }
 

--- a/src/requestHandlers/image.ts
+++ b/src/requestHandlers/image.ts
@@ -1,5 +1,4 @@
 import * as imageService from '../services/imageService';
-import * as panelSetService from '../services/panelSetService';
 
 import { sanitizeResponse, assertArgumentsString, assertArgumentsNumber } from './utils';
 import { Request, Response } from 'express';
@@ -100,10 +99,11 @@ const _getAllImageUrlsByPanelSetIdController = async (id: number) => {
     try {
         const panels = await imageService.getAllImagesByPanelSetId(sequelize)(id) as IPanel[];
         return await Promise.all(panels.map(async (panel) => await imageService.getImage(panel.image)));
-    } catch (error) {
+    }
+    catch (error) {
         return error;
     }
-}
+};
 
 
 // save an image request
@@ -124,5 +124,5 @@ const validateImageFile = (file: Express.Multer.File | null): boolean => {
 
 
 export {
-    getAllImageUrlsByPanelSetId,  _getAllImageUrlsByPanelSetIdController, saveImage, getImage, _saveImageController, _getImageController, validateImageFile
+    getAllImageUrlsByPanelSetId, _getAllImageUrlsByPanelSetIdController, saveImage, getImage, _saveImageController, _getImageController, validateImageFile
 };

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -18,48 +18,27 @@ const populate = async (request: Request, res: Response) => {
 const uploadImagesPopulate = async (request: Request, res: Response) => {
 
      // get image files
-    const files = request.files as { [fieldname: string]: Express.Multer.File[] };
+    const files = request.files as Express.Multer.File[] ;
 
     // check if not there
     if (!files) {
         return res.status(400).json({ message: 'No files uploaded' });
     }
 
-    // get specific image data
-    const panelImage1 = files['image1'] ? files['image1'][0] : null;
-    const panelImage2 = files['image2'] ? files['image2'][0] : null;
-    const panelImage3 = files['image3'] ? files['image3'][0] : null;
-    const panelImage4 = files['image4'] ? files['image4'][0] : null;
-    const panelImage5 = files['image5'] ? files['image5'][0] : null;
-    const panelImage6 = files['image6'] ? files['image6'][0] : null;
-
-
     // make sure all six exist
-    if (!panelImage1 || !panelImage2 || !panelImage3 || !panelImage4 || !panelImage5 ||  !panelImage6) {
+    if (files.length !== 6) {
         return res.status(400).json({ message: 'Exactly three images files must be uploaded' });
     }
 
-    // Validate all three images
-    if (!validateImageFile(panelImage1)) {
-        return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
-    }
-    if (!validateImageFile(panelImage2)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
-    }
-    if (!validateImageFile(panelImage3)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
-    }
-    if (!validateImageFile(panelImage4)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
-    }
-    if (!validateImageFile(panelImage5)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
-    }
-    if (!validateImageFile(panelImage6)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
-    }
+    files.forEach(file =>{
+         // Validate all three images
+        if (!validateImageFile(file)) {
+            return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
+        }
+    })
 
-    const response = await _populate(sequelize, [panelImage1, panelImage2, panelImage3, panelImage4, panelImage5, panelImage6])();
+
+    const response = await _populate(sequelize, files)();
     return sanitizeResponse(response, res, '');
 };
 

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -28,10 +28,14 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
     // get specific image data
     const panelImage1 = files['image1'] ? files['image1'][0] : null;
     const panelImage2 = files['image2'] ? files['image2'][0] : null;
+    const panelImage3 = files['image1'] ? files['image1'][0] : null;
+    const panelImage4 = files['image2'] ? files['image2'][0] : null;
+    const panelImage5 = files['image1'] ? files['image1'][0] : null;
+    const panelImage6 = files['image2'] ? files['image2'][0] : null;
 
 
-    // make sure all three exist
-    if (!panelImage1 || !panelImage2) {
+    // make sure all six exist
+    if (!panelImage1 || !panelImage2 || !panelImage3 || !panelImage4 || !panelImage5 ||  !panelImage6) {
         return res.status(400).json({ message: 'Exactly three images files must be uploaded' });
     }
 
@@ -42,8 +46,20 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
     if (!validateImageFile(panelImage2)) {
         return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
     }
+    if (!validateImageFile(panelImage3)) {
+        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+    }
+    if (!validateImageFile(panelImage4)) {
+        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+    }
+    if (!validateImageFile(panelImage5)) {
+        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+    }
+    if (!validateImageFile(panelImage6)) {
+        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+    }
 
-    const response = await _populate(sequelize, [panelImage1, panelImage2])();
+    const response = await _populate(sequelize, [panelImage1, panelImage2, panelImage3, panelImage4, panelImage5, panelImage6])();
     return sanitizeResponse(response, res, '');
 };
 
@@ -69,12 +85,12 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         const hook4 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
         const hook5 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
         const hook6 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
-        const publishes = [await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook1, undefined) as any,
-            await _publishController(sequelize)(user.id, panelImages[1], panelImages[1], panelImages[1], hook2, 1) as any,
-            await _publishController(sequelize)(user.id, panelImages[1], panelImages[1], panelImages[1], hook3, 3) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook4, 2) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook5, 9) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook6, 4) as any];
+        const publishes = [await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
+            await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook2, 1) as any,
+            await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook3, 3) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook4, 2) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook5, 9) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any];
         return publishes.map(p => p instanceof Error ? p.message : p);
     }
     catch (err) {

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -17,8 +17,8 @@ const populate = async (request: Request, res: Response) => {
 
 const uploadImagesPopulate = async (request: Request, res: Response) => {
 
-     // get image files
-    const files = request.files as Express.Multer.File[] ;
+    // get image files
+    const files = request.files as Express.Multer.File[];
 
     // check if not there
     if (!files) {
@@ -31,11 +31,12 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
     }
 
     files.forEach(file =>{
-         // Validate all three images
+
+        // Validate all three images
         if (!validateImageFile(file)) {
             return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
         }
-    })
+    });
 
 
     const response = await _populate(sequelize, files)();
@@ -52,7 +53,7 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
             display_name: 'display'
         }) as IUser;
 
-        if(panelImages.length === 0){
+        if (panelImages.length === 0) {
             panelImages.push({} as Express.Multer.File);
             panelImages.push({} as Express.Multer.File);
         }
@@ -64,13 +65,15 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         const hook4 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
         const hook5 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
         const hook6 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
-        const publishes = [await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
+        const publishes = [
+await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
             await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook2, 1) as any,
             await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook3, 3) as any,
             await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook4, 2) as any,
             await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook5, 9) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any];
-        return publishes.map(p => p instanceof Error ? p.message : p);
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any
+        ];
+        return publishes.map(p => (p instanceof Error ? p.message : p));
     }
     catch (err) {
         return err;

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -55,6 +55,10 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         if(panelImages.length === 0){
             panelImages.push({} as Express.Multer.File);
             panelImages.push({} as Express.Multer.File);
+            panelImages.push({} as Express.Multer.File);
+            panelImages.push({} as Express.Multer.File);
+            panelImages.push({} as Express.Multer.File);
+            panelImages.push({} as Express.Multer.File);
         }
         const hookString = JSON.parse(`{ "position":[{"x": 1, "y": 1}]}`);
 

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -28,10 +28,10 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
     // get specific image data
     const panelImage1 = files['image1'] ? files['image1'][0] : null;
     const panelImage2 = files['image2'] ? files['image2'][0] : null;
-    const panelImage3 = files['image1'] ? files['image1'][0] : null;
-    const panelImage4 = files['image2'] ? files['image2'][0] : null;
-    const panelImage5 = files['image1'] ? files['image1'][0] : null;
-    const panelImage6 = files['image2'] ? files['image2'][0] : null;
+    const panelImage3 = files['image3'] ? files['image3'][0] : null;
+    const panelImage4 = files['image4'] ? files['image4'][0] : null;
+    const panelImage5 = files['image5'] ? files['image5'][0] : null;
+    const panelImage6 = files['image6'] ? files['image6'][0] : null;
 
 
     // make sure all six exist

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import { Sequelize } from 'sequelize';
 import { sequelize } from '../database';
 import * as UserService from '../services/userService';
+import { validateImageFile } from './image';
 
 import { IUser } from '../models';
 import { _publishController } from './publish';
@@ -14,7 +15,39 @@ const populate = async (request: Request, res: Response) => {
     return sanitizeResponse(response, res, '');
 };
 
-const _populate = (sequelize: Sequelize) => async() => {
+const uploadImagesPopulate = async (request: Request, res: Response) => {
+
+     // get image files
+    const files = request.files as { [fieldname: string]: Express.Multer.File[] };
+
+    // check if not there
+    if (!files) {
+        return res.status(400).json({ message: 'No files uploaded' });
+    }
+
+    // get specific image data
+    const panelImage1 = files['image1'] ? files['image1'][0] : null;
+    const panelImage2 = files['image2'] ? files['image2'][0] : null;
+
+
+    // make sure all three exist
+    if (!panelImage1 || !panelImage2) {
+        return res.status(400).json({ message: 'Exactly three images files must be uploaded' });
+    }
+
+    // Validate all three images
+    if (!validateImageFile(panelImage1)) {
+        return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
+    }
+    if (!validateImageFile(panelImage2)) {
+        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+    }
+
+    const response = await _populate(sequelize, [panelImage1, panelImage2])();
+    return sanitizeResponse(response, res, '');
+};
+
+const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File> = []) => async() => {
     try {
 
         // create a user
@@ -24,7 +57,10 @@ const _populate = (sequelize: Sequelize) => async() => {
             display_name: 'display'
         }) as IUser;
 
-        const image = {} as Express.Multer.File;
+        if(panelImages.length === 0){
+            panelImages.push({} as Express.Multer.File);
+            panelImages.push({} as Express.Multer.File);
+        }
         const hookString = JSON.parse(`{ "position":[{"x": 1, "y": 1}]}`);
 
         const hook1 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
@@ -33,12 +69,12 @@ const _populate = (sequelize: Sequelize) => async() => {
         const hook4 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
         const hook5 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
         const hook6 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
-        const publishes = [await _publishController(sequelize)(user.id, image, image, image, hook1, undefined) as any,
-            await _publishController(sequelize)(user.id, image, image, image, hook2, 1) as any,
-            await _publishController(sequelize)(user.id, image, image, image, hook3, 3) as any,
-            await _publishController(sequelize)(user.id, image, image, image, hook4, 2) as any,
-            await _publishController(sequelize)(user.id, image, image, image, hook5, 9) as any,
-            await _publishController(sequelize)(user.id, image, image, image, hook6, 4) as any];
+        const publishes = [await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook1, undefined) as any,
+            await _publishController(sequelize)(user.id, panelImages[1], panelImages[1], panelImages[1], hook2, 1) as any,
+            await _publishController(sequelize)(user.id, panelImages[1], panelImages[1], panelImages[1], hook3, 3) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook4, 2) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook5, 9) as any,
+            await _publishController(sequelize)(user.id, panelImages[0], panelImages[0], panelImages[0], hook6, 4) as any];
         return publishes.map(p => p instanceof Error ? p.message : p);
     }
     catch (err) {
@@ -46,4 +82,4 @@ const _populate = (sequelize: Sequelize) => async() => {
     }
 };
 
-export { populate };
+export { populate, uploadImagesPopulate };

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -119,7 +119,7 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
         data = JSON.parse(request.body.data);
     }
     catch (e) {
-        return res.status(400).json({ error: 'data is not valid JSON and cannot be accepted' });
+        return res.status(400).json({ message: 'data is not valid JSON and cannot be accepted' });
     }
 
     // get the author data
@@ -153,13 +153,13 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
 
     // Validate all three images
     if (!validateImageFile(panelImage1)) {
-        return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
+        return res.status(400).json({ message: 'Uploaded file 1 must be an image' });
     }
     if (!validateImageFile(panelImage2)) {
-        return res.status(400).json({ error: 'Uploaded file 2 must be an image' });
+        return res.status(400).json({ message: 'Uploaded file 2 must be an image' });
     }
     if (!validateImageFile(panelImage3)) {
-        return res.status(400).json({ error: 'Uploaded file 3 must be an image' });
+        return res.status(400).json({ message: 'Uploaded file 3 must be an image' });
     }
 
 
@@ -167,9 +167,9 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
     const hooks = data.hooks;
 
     // ensure hooks exist
-    if (!hooks) return res.status(400).json({ error: 'No hooks uploaded' });
+    if (!hooks) return res.status(400).json({ message: 'No hooks uploaded' });
 
-    if (!Array.isArray(hooks) || hooks.length != 3) return res.status(400).json({ error: '3 hooks need to be uploaded.' });
+    if (!Array.isArray(hooks) || hooks.length != 3) return res.status(400).json({ message: '3 hooks need to be uploaded.' });
 
     // validate
     for (let i = 0; i < hooks.length; i++) {

--- a/src/requestHandlers/utils.ts
+++ b/src/requestHandlers/utils.ts
@@ -109,7 +109,7 @@ const assertArguments = (
     args: { [key: string]: any },
     predicate: (value: any) => boolean,
     message: string
-): { success: boolean, messages?: string[] } => {
+): { success: boolean, message?: string } => {
 
     // collect a list of error messages for invalid arguments
     const messages: string[] = [];
@@ -118,7 +118,7 @@ const assertArguments = (
     });
     if (messages.length > 0) return {
         success: false,
-        messages
+        message: messages.join('. ')
     };
     return { success: true };
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,14 +49,7 @@ export default (app: Express) => {
         { name: 'image3', maxCount: 1 }
     ]), publish.publish);
     app.post('/saveimage', upload.single('image'), image.saveImage);
-    app.post('/uploadImages',upload.fields([
-        { name: 'image1', maxCount: 1 },
-        { name: 'image2', maxCount: 1 },
-        { name: 'image3', maxCount: 1 },
-        { name: 'image4', maxCount: 1 },
-        { name: 'image5', maxCount: 1 },
-        { name: 'image6', maxCount: 1 }]
-    ), populate.uploadImagesPopulate);
+    app.post('/uploadImages',upload.array('images', 6), populate.uploadImagesPopulate);
 
     app.post('/createHook', hook.createHook);
     app.post('/createPanel', panel.createPanel);

--- a/src/router.ts
+++ b/src/router.ts
@@ -50,7 +50,11 @@ export default (app: Express) => {
     app.post('/saveimage', upload.single('image'), image.saveImage);
     app.post('/uploadImages',upload.fields([
         { name: 'image1', maxCount: 1 },
-        { name: 'image2', maxCount: 1 }]
+        { name: 'image2', maxCount: 1 },
+        { name: 'image3', maxCount: 1 },
+        { name: 'image4', maxCount: 1 },
+        { name: 'image5', maxCount: 1 },
+        { name: 'image6', maxCount: 1 }]
     ), populate.uploadImagesPopulate);
 
     app.post('/createHook', hook.createHook);

--- a/src/router.ts
+++ b/src/router.ts
@@ -48,6 +48,10 @@ export default (app: Express) => {
         { name: 'image3', maxCount: 1 }
     ]), publish.publish);
     app.post('/saveimage', upload.single('image'), image.saveImage);
+    app.post('/uploadImages',upload.fields([
+        { name: 'image1', maxCount: 1 },
+        { name: 'image2', maxCount: 1 }]
+    ), populate.uploadImagesPopulate);
 
     app.post('/createHook', hook.createHook);
     app.post('/createPanel', panel.createPanel);

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,6 +29,7 @@ export default (app: Express) => {
 
     app.get('/hook/:id', hook.getHook);
     app.get('/panel/:id', panel.getPanel);
+    app.get('/panel_sets/:id/hooks', hook.getAllHooksByPanelSetId);
     app.get('/panel/:id/hooks', hook.getPanelHooks);
     app.get('/panel_set/:id', panelSet.getPanelSetByID);
     app.get('/panel_sets/:ids/panels', panel.getPanelsFromPanelSetIDs);

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,6 +31,7 @@ export default (app: Express) => {
     app.get('/panel/:id', panel.getPanel);
     app.get('/panel_sets/:id/hooks', hook.getAllHooksByPanelSetId);
     app.get('/panel/:id/hooks', hook.getPanelHooks);
+    app.get('/panel_set/:id/images', image.getAllImageUrlsByPanelSetId);
     app.get('/panel_set/:id', panelSet.getPanelSetByID);
     app.get('/panel_sets/:ids/panels', panel.getPanelsFromPanelSetIDs);
     app.get('/panel_set/:panel_set_id/:index/panel', panel.getPanelBasedOnPanelSetAndIndex);

--- a/src/router.ts
+++ b/src/router.ts
@@ -54,7 +54,6 @@ export default (app: Express) => {
     app.post('/createPanelSet', panelSet.createPanelSet);
     app.post('/createUser', user.createUser);
 
-    // authentication needs to change soon
     app.post('/authenticate', user.authenticate);
     app.post('/createSession', session.createSession);
     app.post('/changePassword', user.changePassword);

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,7 +49,7 @@ export default (app: Express) => {
         { name: 'image3', maxCount: 1 }
     ]), publish.publish);
     app.post('/saveimage', upload.single('image'), image.saveImage);
-    app.post('/uploadImages',upload.array('images', 6), populate.uploadImagesPopulate);
+    app.post('/uploadImages', upload.array('images', 6), populate.uploadImagesPopulate);
 
     app.post('/createHook', hook.createHook);
     app.post('/createPanel', panel.createPanel);

--- a/src/s3Init.ts
+++ b/src/s3Init.ts
@@ -35,7 +35,7 @@ try {
     };
 
     // config for actual s3
-    /*const trueConfig = {
+    /* const trueConfig = {
         credentials: {
             accessKeyId:     process.env.S3_ACCESS_KEY as string,
             secretAccessKey: process.env.S3_SECRET_ACCESS_KEY as string,

--- a/src/services/hookService.ts
+++ b/src/services/hookService.ts
@@ -1,6 +1,7 @@
 import { Sequelize, Transaction } from 'sequelize';
-import { IHook, IPanel } from '../models';
+import { IHook, IPanel, IPanelSet } from '../models';
 import { Json } from 'sequelize/types/utils';
+import { sequelize } from '../database';
 
 interface HookConfig {
     position: Json,
@@ -38,6 +39,21 @@ const createHook = (sequelize: Sequelize, transaction?: Transaction) => async (n
         id, position, current_panel_id, next_panel_set_id
     } as HookCreateInfo;
 };
+
+const getAllHooksByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
+    return await sequelize.models.hook.findAll({
+        include: [{
+          model: sequelize.models.panel,
+          required: true,
+          include: [{
+            model: sequelize.models.panel_set,
+            where: { id: panel_set_id },
+            required: true
+          }]
+        }],
+        order: [ ['id', 'ASC'] ]
+      });
+}
 
 /**
  * Gets a single hook based on id
@@ -108,5 +124,5 @@ const addSetToHook = (sequelize: Sequelize, transaction? : Transaction) => async
 };
 
 export {
-    createHook, getHook, getPanelHooks, addSetToHook
+    createHook, getHook, getPanelHooks, addSetToHook, getAllHooksByPanelSetId
 };

--- a/src/services/hookService.ts
+++ b/src/services/hookService.ts
@@ -1,7 +1,6 @@
 import { Sequelize, Transaction } from 'sequelize';
-import { IHook, IPanel, IPanelSet } from '../models';
+import { IHook, IPanel } from '../models';
 import { Json } from 'sequelize/types/utils';
-import { sequelize } from '../database';
 
 interface HookConfig {
     position: Json,
@@ -42,18 +41,22 @@ const createHook = (sequelize: Sequelize, transaction?: Transaction) => async (n
 
 const getAllHooksByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
     return await sequelize.models.hook.findAll({
-        include: [{
-          model: sequelize.models.panel,
-          required: true,
-          include: [{
-            model: sequelize.models.panel_set,
-            where: { id: panel_set_id },
-            required: true
-          }]
-        }],
+        include: [
+            {
+                model:    sequelize.models.panel,
+                required: true,
+                include:  [
+                    {
+                        model:    sequelize.models.panel_set,
+                        where:    { id: panel_set_id },
+                        required: true
+                    }
+                ]
+            }
+        ],
         order: [ ['id', 'ASC'] ]
-      });
-}
+    });
+};
 
 /**
  * Gets a single hook based on id

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -32,12 +32,11 @@ const getImage = async(id : string) =>{
     return { url: url };
 };
 
-const getAllImagessByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
-    const images = sequelize.models.panel_set.findAll({
-        where: {
-            panel_set_id: panel_set_id 
-        },
+const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
+    return sequelize.models.panel.findAll({
+        where: { panel_set_id: panel_set_id },
+        attributes: ['image', 'id'],
+        order: [ ['id', 'ASC'] ]
       });
-      console.log(images);
 }
-export { saveImage, getImage };
+export { saveImage, getImage, getAllImagesByPanelSetId };

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -34,9 +34,9 @@ const getImage = async(id : string) =>{
 
 const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
     return sequelize.models.panel.findAll({
-        where: { panel_set_id: panel_set_id },
+        where:      { panel_set_id: panel_set_id },
         attributes: ['image', 'id'],
-        order: [ ['id', 'ASC'] ]
-      });
-}
+        order:      [ ['id', 'ASC'] ]
+    });
+};
 export { saveImage, getImage, getAllImagesByPanelSetId };

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -1,6 +1,7 @@
 import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { s3, bucketName } from '../s3Init';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Sequelize } from 'sequelize';
 
 const saveImage = async(id : string, buffer: Buffer, mimetype : string)=>{
 
@@ -31,4 +32,12 @@ const getImage = async(id : string) =>{
     return { url: url };
 };
 
+const getAllImagessByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {
+    const images = sequelize.models.panel_set.findAll({
+        where: {
+            panel_set_id: panel_set_id 
+        },
+      });
+      console.log(images);
+}
 export { saveImage, getImage };

--- a/src/tests/image.test.ts
+++ b/src/tests/image.test.ts
@@ -2,6 +2,7 @@ import { _getImageController, _saveImageController } from '../requestHandlers/im
 import * as imageService from '../services/imageService';
 jest.mock('../services/imageService');
 
+//todo: make tests for _getAllImagesByPanelSetIdController
 
 describe('Save Image', () => {
     const buffer: Buffer = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);

--- a/src/tests/image.test.ts
+++ b/src/tests/image.test.ts
@@ -2,7 +2,7 @@ import { _getImageController, _saveImageController } from '../requestHandlers/im
 import * as imageService from '../services/imageService';
 jest.mock('../services/imageService');
 
-//todo: make tests for _getAllImagesByPanelSetIdController
+// todo: make tests for _getAllImagesByPanelSetIdController
 
 describe('Save Image', () => {
     const buffer: Buffer = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);


### PR DESCRIPTION
- Add `getAllHooksByPanelSetId` and `getAllImageUrlsByPanelSetId`. These were made to limit the amount of api calls from the front end to the back end on the read page.

- Add `uploadImagesPopulate`. Similar to `populate` but allows images 6 images to be uploaded.

None of these have unit tests due to being crunched for time. `uploadImagesPopulate` should not have unit tests as it is a debug query