### PR TITLE
Cookies for the session

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://user:password@host:port/database
 DATABASE_SSL=false
 
-SECRET_KEY = 'baboon';
+SECRET_SESSION_KEY = 'baboon';
 
 # for unit testing
 TEST_DATABASE_URL=postgres://user:password@host:port/database

--- a/example.env
+++ b/example.env
@@ -1,6 +1,8 @@
 DATABASE_URL=postgres://user:password@host:port/database
 DATABASE_SSL=false
 
+SECRET_KEY = 'baboon';
+
 # for unit testing
 TEST_DATABASE_URL=postgres://user:password@host:port/database
 TEST_DATABASE_SSL=false

--- a/example.env
+++ b/example.env
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://user:password@host:port/database
 DATABASE_SSL=false
 
-SECRET_SESSION_KEY = 'baboon';
+SECRET_SESSION_KEY = 'key value';
 
 # for unit testing
 TEST_DATABASE_URL=postgres://user:password@host:port/database

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express-session": "^1.18.0",
         "helmet": "^7.1.0",
         "jest": "^29.7.0",
+        "jose": "^5.6.3",
         "multer": "^1.4.5-lts.1",
         "password-validator": "^5.3.0",
         "pg": "^8.12.0",
@@ -7925,6 +7926,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "express-session": "^1.18.0",
     "helmet": "^7.1.0",
     "jest": "^29.7.0",
+    "jose": "^5.6.3",
     "multer": "^1.4.5-lts.1",
     "password-validator": "^5.3.0",
     "pg": "^8.12.0",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ import { RequestWithUser } from './requestHandlers/utils';
 dotenv.config();
 
 //setup key
-const key = new TextEncoder().encode(process.env.SECRET_KEY);
+const key = new TextEncoder().encode(process.env.SECRET_SESSION_KEY);
 /**
  * Set the content security policy for our server.
  * @returns 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -73,7 +73,7 @@ const validateSessionPost = async(req : RequestWithUser, res : Response, next: N
 
         const sessionID = await decrypt(session.value);
         const user = await getUserBySession(sequelize)(sessionID.sessionId);
-        if (user === null) throw new Error(`Session with id ${sessionID.sessionId} does not exist and/or failed to get the user by session id. Ensure the session exists on the cookie.`);
+        if (user === null) throw new Error(`Session with id ${sessionID.sessionId} does not exist and/or failed to get the user by session id. Ensure the session on the cookie is for a valid user.`);
         req.user_id = user.id;
 
         // set user

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import * as PanelSetService from '../services/panelSetService';
 import { Sequelize, Transaction, DataTypes } from 'sequelize';
 import {
-    assertArgumentsDefined, assertArgumentsNumber, assertArgumentsString, sanitizeResponse
+    assertArgumentsDefined, assertArgumentsNumber, assertArgumentsString, RequestWithUser, sanitizeResponse
 } from './utils';
 import { sequelize } from '../database';
 import * as UserService from '../services/userService';
@@ -30,8 +30,10 @@ const _createPanelSetController = (sequelize : Sequelize, transaction?: Transact
  * @param res 
  * @returns 
  */
-const createPanelSet = async (request: Request, res: Response) : Promise<Response> => {
-    const author_id = (typeof request.body.author_id === 'string') ? request.body.author_id : '';
+const createPanelSet = async (request: RequestWithUser, res: Response) : Promise<Response> => {
+    // get the author data
+    const author_id = request.user_id;
+    if(!author_id) return res.status(400).json({ message: 'Missing Author Id' });
     const validArgs = assertArgumentsDefined({ author_id });
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _createPanelSetController(sequelize)(author_id);

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -31,9 +31,10 @@ const _createPanelSetController = (sequelize : Sequelize, transaction?: Transact
  * @returns 
  */
 const createPanelSet = async (request: RequestWithUser, res: Response) : Promise<Response> => {
+
     // get the author data
     const author_id = request.user_id;
-    if(!author_id) return res.status(400).json({ message: 'Missing Author Id' });
+    if (!author_id) return res.status(400).json({ message: 'Missing Author Id' });
     const validArgs = assertArgumentsDefined({ author_id });
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _createPanelSetController(sequelize)(author_id);

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -9,8 +9,6 @@ import { createPanel } from '../services/panelService';
 import { addSetToHook, createHook } from '../services/hookService';
 import { Json } from 'sequelize/types/utils';
 import { _saveImageController, validateImageFile } from './image';
-import { _createPanelSetController } from './panelSet';
-import { IPanelSet } from '../models';
 import crypto from 'crypto';
 import { createPanelSet } from '../services/panelSetService';
 
@@ -33,7 +31,7 @@ const _publishController = (sequelize : Sequelize) => async (
     try {
 
         // make panel_set, call the controller as author validation is needed
-        const panel_set = await createPanelSet(sequelize, t)({author_id: author_id});
+        const panel_set = await createPanelSet(sequelize, t)({ author_id: author_id });
 
         // add setTohook
         let hook;
@@ -124,7 +122,7 @@ const publish = async (request: RequestWithUser, res: Response) : Promise<Respon
 
     // get the author data
     const author_id = request.user_id;
-    if(!author_id) return res.status(400).json({ message: 'Missing Author Id' });
+    if (!author_id) return res.status(400).json({ message: 'Missing Author Id' });
 
     // const parent
     const hook_id = data.hook_id;

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { Sequelize } from 'sequelize';
 import {
-    assertArgumentsDefined, assertArgumentsNumber, sanitizeResponse, assertArgumentsPosition
+    assertArgumentsDefined, assertArgumentsNumber, sanitizeResponse, assertArgumentsPosition,
+    RequestWithUser
 } from './utils';
 import { sequelize } from '../database';
 import { createPanel } from '../services/panelService';
@@ -11,6 +12,8 @@ import { _saveImageController, validateImageFile } from './image';
 import { _createPanelSetController } from './panelSet';
 import { IPanelSet } from '../models';
 import crypto from 'crypto';
+import { createPanelSet } from '../services/panelSetService';
+
 
 // types 
 type hook = {position : Json, panel_index : number}
@@ -30,10 +33,7 @@ const _publishController = (sequelize : Sequelize) => async (
     try {
 
         // make panel_set, call the controller as author validation is needed
-        const panel_set = await _createPanelSetController(sequelize, t)(author_id) as IPanelSet | Error;
-
-        // validate panel set creation, if not expected, its an error so throw it
-        if (panel_set instanceof Error) throw panel_set;
+        const panel_set = await createPanelSet(sequelize, t)({author_id: author_id});
 
         // add setTohook
         let hook;
@@ -110,7 +110,7 @@ const _publishController = (sequelize : Sequelize) => async (
  * @param res 
  * @returns 
  */
-const publish = async (request: Request, res: Response) : Promise<Response> => {
+const publish = async (request: RequestWithUser, res: Response) : Promise<Response> => {
 
     let data;
 
@@ -123,7 +123,8 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
     }
 
     // get the author data
-    const author_id = data.author_id;
+    const author_id = request.user_id;
+    if(!author_id) return res.status(400).json({ message: 'Missing Author Id' });
 
     // const parent
     const hook_id = data.hook_id;

--- a/src/requestHandlers/utils.ts
+++ b/src/requestHandlers/utils.ts
@@ -196,6 +196,10 @@ const assertArgumentsPosition = (positionsObjects : Json)=>{
     );
 };
 
+interface RequestWithUser extends Request {
+    user_id?: string;
+}
+
 export {
     validatePassword,
     validateDisplayName,
@@ -207,5 +211,6 @@ export {
     assertArgumentsString,
     sanitizeResponse,
     notFound,
-    assertArgumentsPosition
+    assertArgumentsPosition,
+    RequestWithUser
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,9 +33,12 @@ setupDatabase().then(() => {
 
     // set content security policy
     app.use(helpers.setCSP);
-    app.use(helpers.errorHandler);
 
     // session setup
+    app.use(helpers.validateSessionPost)
+
+    //error handling 
+    app.use(helpers.errorHandler);
 
     // host swagger OAS spec file
     app.use('/help', helpers.swaggerCSP, swaggerUI.serve, swaggerUI.setup(swaggerDocument));

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,9 +35,9 @@ setupDatabase().then(() => {
     app.use(helpers.setCSP);
 
     // session setup
-    app.use(helpers.validateSessionPost)
+    app.use(helpers.validateSessionPost);
 
-    //error handling 
+    // error handling 
     app.use(helpers.errorHandler);
 
     // host swagger OAS spec file


### PR DESCRIPTION
# Description
Added middleware that checks most POST requests for a cookie with session data. It ignores session and user creation POST requests and testing queries. It validates the cookie and adds a `user_id` to the `request` which can be used within additional layers of the database.

To test: sign in to the site and everything should work as normal for publish. In postman, if you make a post request, it should fail unless there is a cookie that matches the front end cookie.
## Specific Changes:
#.env
Added a `SECRET_SESSION_KEY` for decrypting the session, along with the `jose` package.

#helpers
Added a decrypt and a validateSessionPost, which checks the request cookie and validates a session id with a user. It then appends the user id to the request. If anything fails, and error is thrown.

#publish
No longer needs to user createPanelSetController, and just calls the service instead

## Known Issues
Throws a fail to fetch error 100% of time from middleware, not the specific error I throw.
Test this with a future pr called `` in the front end.





