### PR TITLE
Panel set name

### DIFF
--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -835,10 +835,37 @@
     },
     "/uploadImages": {
       "post": {
+        "tags": [
+          "populate"
+        ],
         "description": "",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "images",
+            "in": "formData",
+            "type": "file[]",
+            "required": true,
+            "description": "Files."
+          }
+        ],
         "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/publishResponse"
+            },
+            "description": "OK"
+          },
           "400": {
-            "description": "Bad Request"
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
@@ -934,6 +961,9 @@
               "type": "object",
               "properties": {
                 "author_id": {
+                  "example": "any"
+                },
+                "name": {
                   "example": "any"
                 }
               }

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -340,34 +340,18 @@
     },
     "/panel_sets/{ids}/panels": {
       "get": {
-        "tags": [
-          "panel"
-        ],
         "description": "",
         "parameters": [
           {
             "name": "ids",
             "in": "path",
             "required": true,
-            "type": "string",
-            "description": "Array of numbers ex: 1-2-3-4"
+            "type": "string"
           }
         ],
         "responses": {
-          "200": {
-            "description": "An array of panels",
-            "schema": {
-              "$ref": "#/definitions/panelArray"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
+          "default": {
+            "description": ""
           }
         }
       }
@@ -844,11 +828,46 @@
         ],
         "parameters": [
           {
-            "name": "images",
+            "name": "image1",
             "in": "formData",
-            "type": "file[]",
+            "type": "file",
             "required": true,
-            "description": "Files."
+            "description": "The file of the image for panel-1."
+          },
+          {
+            "name": "image2",
+            "in": "formData",
+            "type": "file",
+            "required": true,
+            "description": "The file of the image for panel-2."
+          },
+          {
+            "name": "image3",
+            "in": "formData",
+            "type": "file",
+            "required": true,
+            "description": "The file of the image for panel-3."
+          },
+          {
+            "name": "image4",
+            "in": "formData",
+            "type": "file",
+            "required": true,
+            "description": "The file of the image for panel-3."
+          },
+          {
+            "name": "image5",
+            "in": "formData",
+            "type": "file",
+            "required": true,
+            "description": "The file of the image for panel-3."
+          },
+          {
+            "name": "image6",
+            "in": "formData",
+            "type": "file",
+            "required": true,
+            "description": "The file of the image for panel-3."
           }
         ],
         "responses": {
@@ -857,139 +876,6 @@
               "$ref": "#/definitions/publishResponse"
             },
             "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/createHook": {
-      "post": {
-        "tags": [
-          "hook"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "position": {
-                  "example": "any"
-                },
-                "current_panel_id": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A hook",
-            "schema": {
-              "$ref": "#/definitions/hook"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/createPanel": {
-      "post": {
-        "tags": [
-          "panel"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Create Panel",
-            "schema": {
-              "$ref": "#/definitions/panelCreate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A newly created panel",
-            "schema": {
-              "$ref": "#/definitions/panel"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/createPanelSet": {
-      "post": {
-        "tags": [
-          "panel-set"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "author_id": {
-                  "example": "any"
-                },
-                "name": {
-                  "example": "any"
-                }
-              }
-            },
-            "description": "Create a new panel set"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the new panel set",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "number",
-                  "example": 0
-                },
-                "author_id": {
-                  "type": "string",
-                  "example": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            }
           },
           "400": {
             "description": "Bad Request",

--- a/src/api-manual-spec.json
+++ b/src/api-manual-spec.json
@@ -1,37 +1,39 @@
 {
     "info": {
-        "title":       "Crowd Comic API",
+        "title": "Crowd Comic API",
         "description": "API endpoints for Crowd Comic. Keep in mind many of these endpoints are subject to change as the API continues to grow. Authentication is likely the first thing to change when the site implements logging in and session based authentication.",
-        "contact":     {
-            "name":  "",
+        "contact": {
+            "name": "",
             "email": "",
-            "url":   ""
+            "url": ""
         },
         "version": "1.0.0"
     },
     "host": "localhost:4000",
     "servers": [
         {
-            "url":         "http://localhost:4000/",
+            "url": "http://localhost:4000/",
             "description": "Local server"
         },
         {
-            "url":         "<your live url here>",
+            "url": "<your live url here>",
             "description": "Live server"
         }
     ],
     "definitions": {
         "userDefinition": {
-            "email":        "example@example.com",
-            "password":     "asdfASDF1234",
+            "email": "example@example.com",
+            "password": "asdfASDF1234",
             "display_name": "John Doe"
         },
         "userResponse": {
-            "email":        "example@example.com",
+            "email": "example@example.com",
             "display_name": "John Doe",
-            "id":           "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+            "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         },
-        "error": { "message": "string | string[]" },
+        "error": {
+            "message": "string | string[]"
+        },
         "hook": {
             "id": 0,
             "position": "{ [{\"x\": 4, \"y\": 1}, {\"x\": 4, \"y\": 1}] }",
@@ -46,12 +48,11 @@
                         {
                             "x": 4,
                             "y": 1
-                        }
-                    ],
-                    "panel_index": 0
-                },
-                {
-                    "position": [
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
                         {
                             "x": 4,
                             "y": 1
@@ -61,6 +62,31 @@
                 },
                 {
                     "position": [
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        }
+                    ],
+                    "panel_index": 0
+                },
+                {
+                    "position": [
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
                         {
                             "x": 4,
                             "y": 1
@@ -78,12 +104,14 @@
             "panel_set_id": 0
         },
         "panelArray": {
-            "panels":[{
-            "id": 0,
-            "image": "path/to/image",
-            "index": 0,
-            "panel_set_id": 0
-        }]
+            "panels": [
+                {
+                    "id": 0,
+                    "image": "path/to/image",
+                    "index": 0,
+                    "panel_set_id": 0
+                }
+            ]
         },
         "session": {
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -91,18 +119,18 @@
             "createdAt": "2024-07-12T15:29:19.550Z",
             "updatedAt": "2024-07-12T15:29:19.550Z"
         },
-        "panelCreate":{
+        "panelCreate": {
             "image": "sdfe34refergfer4trffs",
             "panel_set_id": 0
         },
-        "panelUpdate":{
+        "panelUpdate": {
             "id": 0,
             "image": "sdfe34refergfer4trffs"
         },
         "publishResponse": {
             "success": "Panel_Set successfully published."
         },
-        "addSetToHookDefinition":{
+        "addSetToHookDefinition": {
             "hook_id": 1,
             "panel_set_id": 1
         }

--- a/src/models/panelSet.model.ts
+++ b/src/models/panelSet.model.ts
@@ -25,7 +25,7 @@ const define = (sequelize: Sequelize): void => {
                 allowNull: false,
             },
             name: {
-                type: DataTypes.STRING,
+                type:      DataTypes.STRING,
                 allowNull: true
             }
         },

--- a/src/models/panelSet.model.ts
+++ b/src/models/panelSet.model.ts
@@ -6,6 +6,7 @@ import { IPanel, IHook } from '../models';
 interface IPanelSet extends Model<InferAttributes<IPanelSet>, InferCreationAttributes<IPanelSet>> {
     id: CreationOptional<number>,
     author_id: string,
+    name: string,
     panels?: NonAttribute<IPanel[]>,
     hook?: NonAttribute<IHook[]>
 }
@@ -22,6 +23,10 @@ const define = (sequelize: Sequelize): void => {
             author_id: {
                 type:      DataTypes.UUID,
                 allowNull: false,
+            },
+            name: {
+                type: DataTypes.STRING,
+                allowNull: true
             }
         },
         {

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -19,61 +19,6 @@ import { _getAllTrunkSetsController } from './panelSet';
  * @returns response or error
  */
 
-
-const _createHookController = (sequelize: Sequelize) => async (position: Json, current_panel_id: number, next_panel_set_id: number|null) => {
-    try {
-        const panel = await getPanel(sequelize)(current_panel_id);
-        if (panel == null) throw new Error('no panel exists for given panel id');
-        if (next_panel_set_id != null) {
-            const valid = await _validateHookConnectionController(sequelize)(next_panel_set_id);
-            if (valid instanceof Error) throw valid;
-        }
-        return await hookService.createHook(sequelize)({
-            position,
-            current_panel_id,
-            next_panel_set_id
-        });
-    }
-    catch (err) {
-        return err;
-    }
-};
-
-/**
- * Create Hook request
- * @param {Request} req 
- * @param {Response} res 
- * @returns 
- */
-const createHook = async (req: Request, res: Response): Promise<Response> => {
-    const position : Json = req.body.position;
-    const current_panel_id : number = req.body.current_panel_id;
-
-    let validArgs = assertArgumentsDefined({ position, current_panel_id });
-    if (!validArgs.success) return res.status(400).json(validArgs);
-
-    // validate position
-    validArgs = assertArgumentsPosition(position);
-    if (!validArgs.success) return res.status(400).json(validArgs);
-
-
-    const response = await _createHookController(sequelize)(position, current_panel_id, null);
-
-    return sanitizeResponse(response, res);
-
-    /*
-        #swagger.tags = ['hook']
-        #swagger.responses[200] = {
-            description: 'A hook',
-            schema: { $ref: '#/definitions/hook' }
-        }
-        #swagger.responses[400] = {
-            schema: { $ref: '#/definitions/error' }
-        }
-        #swagger.responses[500] = {}
-    */
-};
-
 /**
  * Get a hook from its id
  * @param {number} id Hook's id
@@ -296,5 +241,5 @@ const _getAllHooksByPanelSetIdController = (sequelize: Sequelize) => async(panel
     }
 };
 export {
-    getAllHooksByPanelSetId, createHook, getHook, getPanelHooks, addSetToHook, _createHookController, _getHookController, _getPanelHooksController, _addSetToHookController, _validateHookConnectionController, _getAllHooksByPanelSetIdController
+    getAllHooksByPanelSetId, getHook, getPanelHooks, addSetToHook, _getHookController, _getPanelHooksController, _addSetToHookController, _validateHookConnectionController, _getAllHooksByPanelSetIdController
 };

--- a/src/requestHandlers/hook.ts
+++ b/src/requestHandlers/hook.ts
@@ -1,12 +1,9 @@
 import { Request, Response } from 'express';
 import * as hookService from '../services/hookService';
-import {
-    assertArgumentsDefined, assertArgumentsNumber, sanitizeResponse, assertArgumentsPosition
-} from './utils';
+import { assertArgumentsNumber, sanitizeResponse } from './utils';
 import { getPanel } from '../services/panelService';
 import { sequelize } from '../database';
 import { Sequelize } from 'sequelize';
-import { Json } from 'sequelize/types/utils';
 import { IPanelSet } from '../models';
 import { _getAllTrunkSetsController } from './panelSet';
 

--- a/src/requestHandlers/panel.ts
+++ b/src/requestHandlers/panel.ts
@@ -40,37 +40,6 @@ const _createPanelController = (sequelize : Sequelize) => async (image: string, 
     }
 };
 
-// the actual request 
-const createPanel = async (req: Request, res: Response): Promise<Response> => {
-
-    const image: string = req.body.image;
-    const panel_set_id: number = req.body.panel_set_id;
-
-    const validArgs = assertArgumentsDefined({ image, panel_set_id });
-    if (!validArgs.success) return res.status(400).json(validArgs);
-
-    const response = await _createPanelController(sequelize)(image, panel_set_id);
-
-    return sanitizeResponse(response, res);
-
-    /*
-        #swagger.tags = ['panel']
-        #swagger.parameters['body'] = {
-            in: 'body',
-            description: 'Create Panel',
-            schema: { $ref: '#/definitions/panelCreate' }
-        } 
-        #swagger.responses[200] = {
-            description: 'A newly created panel',
-            schema: { $ref: '#/definitions/panel' }
-        }
-        #swagger.responses[400] = {
-            schema: { $ref: '#/definitions/error' }
-        }
-        #swagger.responses[500] = {}
-    */
-};
-
 /**
  * gets a panel based on id
  * @param id The id of the panel
@@ -257,5 +226,5 @@ const getPanelsFromPanelSetIDs = async (req: Request, res: Response): Promise<Re
 };
 
 export {
-    _getPanelsFromPanelSetIDsController, getPanelsFromPanelSetIDs, createPanel, getPanelBasedOnPanelSetAndIndex, getPanel, _createPanelController, _getPanelController, _getPanelBasedOnPanelSetAndIndexController, updatePanel, _updatePanelController
+    _getPanelsFromPanelSetIDsController, getPanelsFromPanelSetIDs, getPanelBasedOnPanelSetAndIndex, getPanel, _createPanelController, _getPanelController, _getPanelBasedOnPanelSetAndIndexController, updatePanel, _updatePanelController
 };

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -13,11 +13,11 @@ import { IPanelSet } from '../models';
  * @param author_id the id of the author who made the panel set
  * @returns 
  */
-const _createPanelSetController = (sequelize : Sequelize, transaction?: Transaction) => async (author_id: string) => {
+const _createPanelSetController = (sequelize : Sequelize, transaction?: Transaction) => async (author_id: string, name: string | null) => {
     try {
         const user = await UserService.getUserByID(sequelize)(author_id);
         if (user == null) throw new Error(`An author with the id "${author_id}" does not exist`);
-        return await PanelSetService.createPanelSet(sequelize, transaction)({ author_id });
+        return await PanelSetService.createPanelSet(sequelize, transaction)({ author_id, name });
     }
     catch (err) {
         return err;
@@ -32,9 +32,10 @@ const _createPanelSetController = (sequelize : Sequelize, transaction?: Transact
  */
 const createPanelSet = async (request: Request, res: Response) : Promise<Response> => {
     const author_id = (typeof request.body.author_id === 'string') ? request.body.author_id : '';
+    const name = !request.body.name && request.body.name !== null ? null : request.body.name;
     const validArgs = assertArgumentsDefined({ author_id });
     if (!validArgs.success) return res.status(400).json(validArgs);
-    const response = await _createPanelSetController(sequelize)(author_id);
+    const response = await _createPanelSetController(sequelize)(author_id, name);
     return sanitizeResponse(response, res);
 
     // API documentation

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -19,30 +19,31 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
 
     // get image files
     const files = request.files as { [fieldname: string]: Express.Multer.File[] };
+
     // check if not there
     if (!files) {
         return res.status(400).json({ message: 'No files uploaded' });
     }
 
     const images = [] as any;
-    for(let i = 1; i < 7; i++) {
-        images.push(files[`image${i}`] ? files[`image${i}`][0] : null)
+    for (let i = 1; i < 7; i++) {
+        images.push(files[`image${i}`] ? files[`image${i}`][0] : null);
     }
 
-    if(images.some((image: any) => !image)) {
+    if (images.some((image: any) => !image)) {
         return res.status(400).json({ message: 'Exactly 6 images files must be uploaded' });
     }
 
     // Validate all 6 images
-    for(let i = 0; i < 6; i++) {
-        if(!validateImageFile(images[i]))
+    for (let i = 0; i < 6; i++) {
+        if (!validateImageFile(images[i]))
             return res.status(400).json({ message: `Uploaded file ${i + 1} must be an image` });
     }
 
     const response = await _populate(sequelize, images)();
     return sanitizeResponse(response, res, '');
 
-     // API documentation
+    // API documentation
     /*
     #swagger.tags = ['populate']
 
@@ -134,15 +135,15 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         const ps18hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
         const ps19hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }];
         const ps20hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
-    
+
         const publishes = [
-        await _publishController(sequelize)(user.id, "Tree 1", panelImages[0], panelImages[1], panelImages[2], ps1hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, 'Tree 1', panelImages[0], panelImages[1], panelImages[2], ps1hooks, undefined) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps2hooks, 1) as any,
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps3hooks, 3) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps4hooks, 2) as any,
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps5hooks, 9) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps6hooks, 4) as any,
-        await _publishController(sequelize)(user.id, "Tree 2", panelImages[0], panelImages[1], panelImages[2], ps7hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, 'Tree 2', panelImages[0], panelImages[1], panelImages[2], ps7hooks, undefined) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps8hooks, 19) as any,
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps9hooks, 20) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps10hooks, 21) as any,
@@ -151,11 +152,11 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps13hooks, 27) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps14hooks, 30) as any,
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps15hooks, 40) as any,
-        await _publishController(sequelize)(user.id, "Tree 3", panelImages[3], panelImages[4], panelImages[5], ps16hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, 'Tree 3', panelImages[3], panelImages[4], panelImages[5], ps16hooks, undefined) as any,
             await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps17hooks, 47) as any,
             await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps18hooks, 48) as any,
-        await _publishController(sequelize)(user.id, "Tree 4", panelImages[0], panelImages[1], panelImages[2], ps19hooks, undefined) as any,
-        await _publishController(sequelize)(user.id, "Tree 5", panelImages[3], panelImages[4], panelImages[5], ps20hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, 'Tree 4', panelImages[0], panelImages[1], panelImages[2], ps19hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, 'Tree 5', panelImages[3], panelImages[4], panelImages[5], ps20hooks, undefined) as any,
         ];
         return publishes.map(p => (p instanceof Error ? p.message : p));
     }

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -18,28 +18,28 @@ const populate = async (request: Request, res: Response) => {
 const uploadImagesPopulate = async (request: Request, res: Response) => {
 
     // get image files
-    const files = request.files as Express.Multer.File[];
-
+    const files = request.files as { [fieldname: string]: Express.Multer.File[] };
     // check if not there
     if (!files) {
         return res.status(400).json({ message: 'No files uploaded' });
     }
 
-    // make sure all six exist
-    if (files.length !== 6) {
-        return res.status(400).json({ message: 'Exactly three images files must be uploaded' });
+    const images = [] as any;
+    for(let i = 1; i < 7; i++) {
+        images.push(files[`image${i}`] ? files[`image${i}`][0] : null)
     }
 
-    files.forEach(file =>{
+    if(images.some((image: any) => !image)) {
+        return res.status(400).json({ message: 'Exactly 6 images files must be uploaded' });
+    }
 
-        // Validate all three images
-        if (!validateImageFile(file)) {
-            return res.status(400).json({ error: 'Uploaded file 1 must be an image' });
-        }
-    });
+    // Validate all 6 images
+    for(let i = 0; i < 6; i++) {
+        if(!validateImageFile(images[i]))
+            return res.status(400).json({ message: `Uploaded file ${i + 1} must be an image` });
+    }
 
-
-    const response = await _populate(sequelize, files)();
+    const response = await _populate(sequelize, images)();
     return sanitizeResponse(response, res, '');
 
      // API documentation
@@ -48,14 +48,42 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
 
     #swagger.consumes = ['multipart/form-data']
 
-    #swagger.parameters['images'] = {
+#swagger.parameters['image1'] = {
         in: 'formData',
-        type: 'file[]',
+        type: 'file',
         required: true,
-        description: 'Files.'
+        description: 'The file of the image for panel-1.'
     }
-
-
+    #swagger.parameters['image2'] = {
+        in: 'formData',
+        type: 'file',
+        required: true,
+        description: 'The file of the image for panel-2.'
+    }
+    #swagger.parameters['image3'] = {
+        in: 'formData',
+        type: 'file',
+        required: true,
+        description: 'The file of the image for panel-3.'
+    }
+    #swagger.parameters['image4'] = {
+        in: 'formData',
+        type: 'file',
+        required: true,
+        description: 'The file of the image for panel-3.'
+    }
+    #swagger.parameters['image5'] = {
+        in: 'formData',
+        type: 'file',
+        required: true,
+        description: 'The file of the image for panel-3.'
+    }
+    #swagger.parameters['image6'] = {
+        in: 'formData',
+        type: 'file',
+        required: true,
+        description: 'The file of the image for panel-3.'
+    }
     #swagger.responses[200] = {
         schema: { $ref: '#/definitions/publishResponse' }
     }
@@ -86,19 +114,48 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         }
         const hookString = JSON.parse(`{ "position":[{"x": 1, "y": 1}]}`);
 
-        const hook1 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
-        const hook2 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
-        const hook3 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
-        const hook4 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
-        const hook5 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
-        const hook6 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps1hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
+        const ps2hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
+        const ps3hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps4hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps5hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps6hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps7hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }];
+        const ps8hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps9hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps10hooks = [{ position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps11hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }];
+        const ps12hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps13hooks = [{ position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps14hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps15hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps16hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }];
+        const ps17hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
+        const ps18hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
+        const ps19hooks = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 0 }, { position: hookString, panel_index: 2 }];
+        const ps20hooks = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 1 }];
+    
         const publishes = [
-await _publishController(sequelize)(user.id, "name", panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
-            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], hook2, 1) as any,
-            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], hook3, 3) as any,
-            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook4, 2) as any,
-            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook5, 9) as any,
-            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any
+        await _publishController(sequelize)(user.id, "Tree 1", panelImages[0], panelImages[1], panelImages[2], ps1hooks, undefined) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps2hooks, 1) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps3hooks, 3) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps4hooks, 2) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps5hooks, 9) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps6hooks, 4) as any,
+        await _publishController(sequelize)(user.id, "Tree 2", panelImages[0], panelImages[1], panelImages[2], ps7hooks, undefined) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps8hooks, 19) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps9hooks, 20) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps10hooks, 21) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps11hooks, 22) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps12hooks, 25) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps13hooks, 27) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps14hooks, 30) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps15hooks, 40) as any,
+        await _publishController(sequelize)(user.id, "Tree 3", panelImages[3], panelImages[4], panelImages[5], ps16hooks, undefined) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], ps17hooks, 47) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], ps18hooks, 48) as any,
+        await _publishController(sequelize)(user.id, "Tree 4", panelImages[0], panelImages[1], panelImages[2], ps19hooks, undefined) as any,
+        await _publishController(sequelize)(user.id, "Tree 5", panelImages[3], panelImages[4], panelImages[5], ps20hooks, undefined) as any,
         ];
         return publishes.map(p => (p instanceof Error ? p.message : p));
     }

--- a/src/requestHandlers/populate.ts
+++ b/src/requestHandlers/populate.ts
@@ -41,6 +41,29 @@ const uploadImagesPopulate = async (request: Request, res: Response) => {
 
     const response = await _populate(sequelize, files)();
     return sanitizeResponse(response, res, '');
+
+     // API documentation
+    /*
+    #swagger.tags = ['populate']
+
+    #swagger.consumes = ['multipart/form-data']
+
+    #swagger.parameters['images'] = {
+        in: 'formData',
+        type: 'file[]',
+        required: true,
+        description: 'Files.'
+    }
+
+
+    #swagger.responses[200] = {
+        schema: { $ref: '#/definitions/publishResponse' }
+    }
+    #swagger.responses[400] = {
+        schema: { $ref: '#/definitions/error' }
+    }
+    #swagger.responses[500] = {}
+*/
 };
 
 const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File> = []) => async() => {
@@ -70,12 +93,12 @@ const _populate = (sequelize: Sequelize, panelImages: Array<Express.Multer.File>
         const hook5 = [{ position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }, { position: hookString, panel_index: 2 }];
         const hook6 = [{ position: hookString, panel_index: 0 }, { position: hookString, panel_index: 1 }, { position: hookString, panel_index: 2 }];
         const publishes = [
-await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
-            await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook2, 1) as any,
-            await _publishController(sequelize)(user.id, panelImages[3], panelImages[4], panelImages[5], hook3, 3) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook4, 2) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook5, 9) as any,
-            await _publishController(sequelize)(user.id, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any
+await _publishController(sequelize)(user.id, "name", panelImages[0], panelImages[1], panelImages[2], hook1, undefined) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], hook2, 1) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[3], panelImages[4], panelImages[5], hook3, 3) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook4, 2) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook5, 9) as any,
+            await _publishController(sequelize)(user.id, null, panelImages[0], panelImages[1], panelImages[2], hook6, 4) as any
         ];
         return publishes.map(p => (p instanceof Error ? p.message : p));
     }

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -18,6 +18,7 @@ type hookArray = Array<hook>;
 
 const _publishController = (sequelize : Sequelize) => async (
     author_id: string,
+    name: string | null,
     panelImage1 : Express.Multer.File,
     panelImage2 : Express.Multer.File,
     panelImage3: Express.Multer.File,
@@ -30,7 +31,7 @@ const _publishController = (sequelize : Sequelize) => async (
     try {
 
         // make panel_set, call the controller as author validation is needed
-        const panel_set = await _createPanelSetController(sequelize, t)(author_id) as IPanelSet | Error;
+        const panel_set = await _createPanelSetController(sequelize, t)(author_id, name) as IPanelSet | Error;
 
         // validate panel set creation, if not expected, its an error so throw it
         if (panel_set instanceof Error) throw panel_set;
@@ -162,8 +163,6 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
         return res.status(400).json({ message: 'Uploaded file 3 must be an image' });
     }
 
-
-
     const hooks = data.hooks;
 
     // ensure hooks exist
@@ -182,9 +181,10 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
         validArgs = assertArgumentsPosition(hooks[i].position);
         if (!validArgs.success) return res.status(400).json(validArgs);
     }
+    const name = request.body.name ?? null;
 
     // call the controller
-    const response = await _publishController(sequelize)(author_id, panelImage1, panelImage2, panelImage3, hooks, hook_id);
+    const response = await _publishController(sequelize)(author_id, name, panelImage1, panelImage2, panelImage3, hooks, hook_id);
 
     return sanitizeResponse(response, res);
 

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -146,7 +146,6 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
     const panelImage2 = files['image2'] ? files['image2'][0] : null;
     const panelImage3 = files['image3'] ? files['image3'][0] : null;
 
-
     // make sure all three exist
     if (!panelImage1 || !panelImage2 || !panelImage3) {
         return res.status(400).json({ message: 'Exactly three images files must be uploaded' });

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -180,7 +180,7 @@ const publish = async (request: Request, res: Response) : Promise<Response> => {
         validArgs = assertArgumentsPosition(hooks[i].position);
         if (!validArgs.success) return res.status(400).json(validArgs);
     }
-    const name = request.body.name ?? null;
+    const name = !request.body.name && request.body.name != null ? null : request.body.name;
 
     // call the controller
     const response = await _publishController(sequelize)(author_id, name, panelImage1, panelImage2, panelImage3, hooks, hook_id);

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -32,7 +32,7 @@ const _publishController = (sequelize : Sequelize) => async (
     try {
 
         // make panel_set, call the controller as author validation is needed
-        const panel_set = await createPanelSet(sequelize, t)({ author_id, name: author_id });
+        const panel_set = await createPanelSet(sequelize, t)({ author_id, name });
 
         // add setTohook
         let hook;

--- a/src/router.ts
+++ b/src/router.ts
@@ -48,13 +48,16 @@ export default (app: Express) => {
         { name: 'image3', maxCount: 1 }
     ]), publish.publish);
     app.post('/saveimage', upload.single('image'), image.saveImage);
-    app.post('/uploadImages', upload.array('images', 6), populate.uploadImagesPopulate);
+    app.post('/uploadImages', upload.fields([
+        { name: 'image1', maxCount: 1 },
+        { name: 'image2', maxCount: 1 },
+        { name: 'image3', maxCount: 1 },
+        { name: 'image4', maxCount: 1 },
+        { name: 'image5', maxCount: 1 },
+        { name: 'image6', maxCount: 1 },
+    ]), populate.uploadImagesPopulate);
 
-    app.post('/createHook', hook.createHook);
-    app.post('/createPanel', panel.createPanel);
-    app.post('/createPanelSet', panelSet.createPanelSet);
     app.post('/createUser', user.createUser);
-
     app.post('/authenticate', user.authenticate);
     app.post('/createSession', session.createSession);
     app.post('/changePassword', user.changePassword);

--- a/src/services/panelSetService.ts
+++ b/src/services/panelSetService.ts
@@ -1,12 +1,14 @@
 import { Sequelize, Transaction } from 'sequelize';
 import { IPanelSet, IUser } from '../models';
 interface PanelSetConfig {
-    author_id: string
+    author_id: string,
+    name: string | null
 }
 
 interface PanelSetInfo {
     id: number;
-    author_id: string
+    author_id: string,
+    name: string | null
 }
 
 
@@ -15,9 +17,9 @@ interface PanelSetInfo {
  * @param {} panelSet 
 */
 const createPanelSet = (sequelize: Sequelize, transaction? : Transaction) => async (panelSet: PanelSetConfig): Promise<PanelSetInfo> => {
-    const { id, author_id } =
-    await sequelize.models.panel_set.create({ author_id: panelSet.author_id }, transaction ? { transaction } : {}) as IPanelSet;
-    return { author_id, id };
+    const { id, author_id, name } =
+    await sequelize.models.panel_set.create({ author_id: panelSet.author_id, name: panelSet.name }, transaction ? { transaction } : {}) as IPanelSet;
+    return { author_id, id, name };
 };
 
 /**


### PR DESCRIPTION
- Add `name` to `panel set` model. This will be used for trunks on the browse page. Will be an optional parameter in the `publish` query
- Made `uploadImages` query bigger in order to test how multiple trees look like on the front end
- Refactored `uploadImages` form-data to take in one image at a time in order to test it using swagger (postman does not like me for some reason)