### PR TITLE
Pass user model through to handler rather than just the id

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -59,7 +59,7 @@ const validateSessionPost = async(req : RequestWithUser, res : Response, next: N
 
         const user = await getUserBySession(sequelize)(session.value);
         if (user === null) throw new Error(`Session with id ${session.value} does not exist and/or failed to get the user by session id. Ensure the session on the cookie is for a valid user.`);
-        req.user_id = user.id;
+        req.user = user;
 
         // set user
         return next();

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -33,7 +33,7 @@ const _createPanelSetController = (sequelize : Sequelize, transaction?: Transact
 const createPanelSet = async (request: RequestWithUser, res: Response) : Promise<Response> => {
 
     // get the author data
-    const author_id = request.user_id;
+    const author_id = request.user?.id;
     if (!author_id) return res.status(400).json({ message: 'Missing Author Id' });
     const name = !request.body.name && request.body.name !== null ? null : request.body.name;
     const validArgs = assertArgumentsDefined({ author_id });

--- a/src/requestHandlers/publish.ts
+++ b/src/requestHandlers/publish.ts
@@ -126,7 +126,7 @@ const publish = async (request: RequestWithUser, res: Response) : Promise<Respon
     }
 
     // get the author data
-    const author_id = request.user_id;
+    const author_id = request.user?.id;
     if (!author_id) return res.status(400).json({ message: 'Missing Author Id' });
 
     // const parent

--- a/src/requestHandlers/utils.ts
+++ b/src/requestHandlers/utils.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import PasswordValidator from 'password-validator';
 import { ValidationError } from 'sequelize';
 import { Json } from 'sequelize/types/utils';
+import { IUser } from '../models';
 
 
 // /**
@@ -197,7 +198,7 @@ const assertArgumentsPosition = (positionsObjects : Json)=>{
 };
 
 interface RequestWithUser extends Request {
-    user_id?: string;
+    user?: IUser;
 }
 
 export {


### PR DESCRIPTION
Quick swap to the user model rather than id. The validatePostRequest will attach a user to the request. Publish and createPanelSet were refactored (1 line) to access the id from this user model object.