### PR TITLE
errors show in postman now

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,8 +29,7 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
         return next(err);
     }
     res.setHeader('Content-Type', 'application/json');
-    res.status(500);
-    res.send(JSON.stringify(err));
+    res.status(500).send(JSON.stringify({message: err.message}));
 };
 
 /**
@@ -48,7 +47,7 @@ const validateSessionPost = async(req : RequestWithUser, res : Response, next: N
         const sessionCookie = req.header('Session-Cookie');
 
         // check if cookie and if session
-        if (!sessionCookie) {
+        if (!sessionCookie || sessionCookie === 'undefined') {
             throw new Error('No session cookie is present in the request. Access denied.');
         }
 


### PR DESCRIPTION
Postman now throws proper error from middleware (front-end doesn't for some reason). And added check for 'undefined' in cookie. Cause it was a string and not actually undefined.