### PR TITLE
Using node env for image links

### DIFF
--- a/seeders/20240725142411-populateTree.js
+++ b/seeders/20240725142411-populateTree.js
@@ -1,6 +1,8 @@
 'use strict';
 /* eslint-disable @typescript-eslint/no-var-requires */
 const bcrypt = require('bcrypt');
+const dotenv = require('dotenv');
+dotenv.config();
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
@@ -35,21 +37,21 @@ module.exports = {
             // create panel
             const panels=await queryInterface.bulkInsert('panels', [
                 {
-                    image:        'http://localhost:5000/crowd-comic/1_9eb775c0-cd4f-4227-9dd8-1af7f9412604',
+                    image:        process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_9eb775c0-cd4f-4227-9dd8-1af7f9412604` : 'http://localhost:5000/crowd-comic/1_9eb775c0-cd4f-4227-9dd8-1af7f9412604',
                     index:        0,
                     panel_set_id: panelSetId,
                     created_at:   '2024-07-23 09:38:33.841-07',
                     updated_at:   '2024-07-23 09:38:33.841-07'
                 },
                 {
-                    image:        'http://localhost:5000/crowd-comic/1_eb071f2a-fe89-43f1-b73b-02175ed77819',
+                    image:        process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_eb071f2a-fe89-43f1-b73b-02175ed77819` : 'http://localhost:5000/crowd-comic/1_eb071f2a-fe89-43f1-b73b-02175ed77819',
                     index:        1,
                     panel_set_id: panelSetId,
                     created_at:   '2024-07-23 09:38:33.841-07',
                     updated_at:   '2024-07-23 09:38:33.841-07'
                 },
                 {
-                    image:        'http://localhost:5000/crowd-comic/1_d94663cb-1d58-4e5f-bf9c-5eba27862475',
+                    image:         process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_d94663cb-1d58-4e5f-bf9c-5eba27862475` : 'http://localhost:5000/crowd-comic/1_d94663cb-1d58-4e5f-bf9c-5eba27862475',
                     index:        2,
                     panel_set_id: panelSetId,
                     created_at:   '2024-07-23 09:38:33.841-07',

--- a/src/s3Init.ts
+++ b/src/s3Init.ts
@@ -8,9 +8,28 @@ import s3rver from 's3rver';
 dotenv.config();
 
 let s3 : S3Client;
-let endpoint : string | undefined;
 let bucketName : string | undefined;
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'production') {
+
+    try {
+
+        // config for actual s3
+        const config = {
+            credentials: {
+                accessKeyId:     process.env.S3_ACCESS_KEY as string,
+                secretAccessKey: process.env.S3_SECRET_ACCESS_KEY as string,
+            },
+            region: process.env.BUCKET_REGION as string,
+        };
+
+        s3 = new S3Client(config);
+        bucketName = process.env.BUCKET_NAME;
+    }
+    catch (error) {
+        console.error('An error occurred s3 setup. Ensure that .env is setup properly and endpoint is correct.', error);
+    }
+}
+else {
     try {
         const aws = new s3rver({
             port:         5000,
@@ -49,30 +68,8 @@ if (process.env.NODE_ENV === 'development') {
 
         s3 = new S3Client(config);
         bucketName = process.env.BUCKET_NAME;
-        endpoint = 'localhost:5000'; // SET TO UNDEFINED WHEN NOT TESTING LOCALLY
 
         setBucketPolicy();
-    }
-    catch (error) {
-        console.error('An error occurred s3 setup. Ensure that .env is setup properly and endpoint is correct.', error);
-    }
-}
-else {
-
-    try {
-
-        // config for actual s3
-        const config = {
-            credentials: {
-                accessKeyId:     process.env.S3_ACCESS_KEY as string,
-                secretAccessKey: process.env.S3_SECRET_ACCESS_KEY as string,
-            },
-            region: process.env.BUCKET_REGION as string,
-        };
-
-        s3 = new S3Client(config);
-        bucketName = process.env.BUCKET_NAME;
-        endpoint = undefined; // SET TO UNDEFINED WHEN NOT TESTING LOCALLY
     }
     catch (error) {
         console.error('An error occurred s3 setup. Ensure that .env is setup properly and endpoint is correct.', error);
@@ -115,4 +112,4 @@ async function setBucketPolicy() {
 setBucketPolicy();
 
 
-export { s3, bucketName, endpoint };
+export { s3, bucketName };

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -1,5 +1,5 @@
 import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
-import { endpoint, s3 } from '../s3Init';
+import { s3 } from '../s3Init';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Sequelize } from 'sequelize';
 
@@ -37,9 +37,8 @@ const getImageSigned = async(id : string) =>{
 
 
 const getImage = (id : string) =>{
-    if (endpoint)
-        return `http://${endpoint}/${process.env.BUCKET_NAME}/${id}`;
-    return `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}`;// https://your-bucket-name.s3.amazonaws.com/path/to/your/file.txt
+    if (process.env.NODE_ENV === 'production') return `http://5000/${process.env.BUCKET_NAME}/${id}`;
+    else  return `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}`;
 };
 
 const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -37,8 +37,7 @@ const getImageSigned = async(id : string) =>{
 
 
 const getImage = (id : string) =>{
-    if (process.env.NODE_ENV === 'production') return `http://5000/${process.env.BUCKET_NAME}/${id}`;
-    else  return `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}`;
+    return process.env.NODE_ENV === 'production' ?  `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}` : `http://localhost:5000/${process.env.BUCKET_NAME}/${id}`;
 };
 
 const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {


### PR DESCRIPTION
### Description
Made use of `NODE_ENV` to swap the image links to images across the backend.

- Swapped the getImage in image service to use `NODE_ENV`
- Modified the seeder to assign a different link to the panel depending on `NODE_ENV`
- Swapped the order in `s3Init` so that anything other than `production` leads to the s3 being run locally as `development`