### PR TITLE
Querying a Panel Set W/O an ID

### DIFF
--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -69,7 +69,12 @@ const _getPanelSetByIDController = (sequelize: Sequelize) => async(id: number) =
 };
 
 const getPanelSetByID = async (request: Request, res: Response) : Promise<Response> => {
-    const id = Number(request.params.id);
+    let id = Number(request.params.id);
+    if(isNaN(id)){
+        const trunks = await PanelSetService.getAllTrunkSets(sequelize) as IPanelSet[];
+        const trunk = trunks[0] as IPanelSet;
+        id = trunk.id;
+    }
     const validArgs = assertArgumentsNumber({ id });
     if (!validArgs.success) return res.status(400).json(validArgs);
     const response = await _getPanelSetByIDController(sequelize)(id);

--- a/src/requestHandlers/panelSet.ts
+++ b/src/requestHandlers/panelSet.ts
@@ -70,7 +70,8 @@ const _getPanelSetByIDController = (sequelize: Sequelize) => async(id: number) =
 
 const getPanelSetByID = async (request: Request, res: Response) : Promise<Response> => {
     let id = Number(request.params.id);
-    if(isNaN(id)){
+    //Endpoint should return the trunk id if no id was provided (no id entered provides NaN as a param)
+    if (isNaN(id)) {
         const trunks = await PanelSetService.getAllTrunkSets(sequelize) as IPanelSet[];
         const trunk = trunks[0] as IPanelSet;
         id = trunk.id;


### PR DESCRIPTION
Calling the `getPanelSetById` endpoint from the database without providing a valid ID number will return the trunk panel set. At the moment, if an ID is provided that _is_ a number but that number is not an id in the database then the query will return an error that no panel set with that ID can be found. Redirection from this error was not requested (and not necessarily something we should do) so for now this is not a feature.

_Needs to be tested with front end PR [171](https://github.com/RIT-Crowd-Comic/site-content/pull/171)_