### PR TITLE
response header fix

### DIFF
--- a/seeders/20240725142411-populateTree.js
+++ b/seeders/20240725142411-populateTree.js
@@ -35,7 +35,7 @@ module.exports = {
             const panelSetId = panelSets[0].id;
 
             // create panel
-            const panels=await queryInterface.bulkInsert('panels', [
+            const panels = await queryInterface.bulkInsert('panels', [
                 {
                     image:        process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_9eb775c0-cd4f-4227-9dd8-1af7f9412604` : 'http://localhost:5000/crowd-comic/1_9eb775c0-cd4f-4227-9dd8-1af7f9412604',
                     index:        0,
@@ -51,13 +51,13 @@ module.exports = {
                     updated_at:   '2024-07-23 09:38:33.841-07'
                 },
                 {
-                    image:         process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_d94663cb-1d58-4e5f-bf9c-5eba27862475` : 'http://localhost:5000/crowd-comic/1_d94663cb-1d58-4e5f-bf9c-5eba27862475',
+                    image:        process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/1_d94663cb-1d58-4e5f-bf9c-5eba27862475` : 'http://localhost:5000/crowd-comic/1_d94663cb-1d58-4e5f-bf9c-5eba27862475',
                     index:        2,
                     panel_set_id: panelSetId,
                     created_at:   '2024-07-23 09:38:33.841-07',
                     updated_at:   '2024-07-23 09:38:33.841-07'
                 },
-            ], {returning: ['id'], transaction });
+            ], { returning: ['id'], transaction });
 
             // create hooks
             await queryInterface.bulkInsert('hooks', [
@@ -70,14 +70,14 @@ module.exports = {
                 },
                 {
                     position:          `[{ "x": 1, "y": 1 }, { "x": 201, "y": 1 }, { "x": 201, "y": 201 }, { "x": 1, "y": 201 }]`,
-                    current_panel_id:   panels[1].id,
+                    current_panel_id:  panels[1].id,
                     next_panel_set_id: null,
                     created_at:        '2024-07-23 09:38:33.841-07',
                     updated_at:        '2024-07-23 09:38:33.841-07'
                 },
                 {
                     position:          `[{ "x": 1, "y": 1 }, { "x": 201, "y": 1 }, { "x": 201, "y": 201 }, { "x": 1, "y": 201 }]`,
-                    current_panel_id:   panels[2].id,
+                    current_panel_id:  panels[2].id,
                     next_panel_set_id: null,
                     created_at:        '2024-07-23 09:38:33.841-07',
                     updated_at:        '2024-07-23 09:38:33.841-07'

--- a/src/api-autogen-spec.json
+++ b/src/api-autogen-spec.json
@@ -677,16 +677,6 @@
         }
       }
     },
-    "/populate": {
-      "get": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/session/{id}": {
       "get": {
         "description": "",
@@ -756,52 +746,6 @@
           "200": {
             "schema": {
               "$ref": "#/definitions/publishResponse"
-            },
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/saveimage": {
-      "post": {
-        "tags": [
-          "image"
-        ],
-        "description": "",
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "parameters": [
-          {
-            "name": "image",
-            "in": "formData",
-            "type": "file",
-            "required": true,
-            "description": "The file of the image to save."
-          }
-        ],
-        "responses": {
-          "200": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "example": "image-id"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
             },
             "description": "OK"
           },
@@ -1192,84 +1136,6 @@
           },
           "500": {
             "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/addSetToHook": {
-      "patch": {
-        "tags": [
-          "hook"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Connect a hook to a panel_set",
-            "schema": {
-              "$ref": "#/definitions/addSetToHookDefinition"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The altered hook",
-            "schema": {
-              "$ref": "#/definitions/hook"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        },
-                        "example": {
-                          "type": "string",
-                          "example": "unable to link panel set with id ${panel_set_id} to hook with id ${hook_id}"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/destroy": {
-      "delete": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
           }
         }
       }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,8 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
         return next(err);
     }
     res.setHeader('Content-Type', 'application/json');
-    res.status(500).send(JSON.stringify({ message: err.message }));
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    return res.status(500).json({message: err.message});
 };
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,8 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
         return next(err);
     }
     res.setHeader('Content-Type', 'application/json');
-    res.status(500).send(JSON.stringify({message: err.message}));
+    res.setHeader('Access-Control-Allow-Origin', 'no-cors');
+    return res.status(500).json({message: err.message});
 };
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -30,7 +30,7 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
     }
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Access-Control-Allow-Origin', '*');
-    return res.status(500).json({message: err.message});
+    return res.status(500).json({ message: err.message });
 };
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,7 @@ const errorHandler = (err: any, req: Request, res: Response, next: NextFunction)
         return next(err);
     }
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader('Access-Control-Allow-Origin', 'no-cors');
+    res.setHeader('Access-Control-Allow-Origin', '*');
     return res.status(500).json({message: err.message});
 };
 

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -37,7 +37,7 @@ const getImageSigned = async(id : string) =>{
 
 
 const getImage = (id : string) =>{
-    return process.env.NODE_ENV === 'production' ?  `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}` : `http://localhost:5000/${process.env.BUCKET_NAME}/${id}`;
+    return process.env.NODE_ENV === 'production' ? `http://${process.env.BUCKET_NAME}.s3.amazonaws.com/${id}` : `http://localhost:5000/${process.env.BUCKET_NAME}/${id}`;
 };
 
 const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: number) => {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -66,10 +66,10 @@ const authenticate = (sequelize : Sequelize) => async (email: string, password: 
 const changePassword = (sequelize : Sequelize) => async (email: string, password: string, newPassword: string): Promise<boolean> => {
 
     // check if current email/password are correct
-    const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;;
+    const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;
     if (!user) return false;
     const match = await bcrypt.compare(password, user.password);
-    if(!match) return false;
+    if (!match) return false;
 
     await user.update({ password: await bcrypt.hash(newPassword, PASSWORD_SALT_ROUNDS) });
     return true;
@@ -83,8 +83,8 @@ const changePassword = (sequelize : Sequelize) => async (email: string, password
 const changeDisplayName = (sequelize : Sequelize) => async (email: string, password: string, newDisplayName: string): Promise<boolean> => {
 
     // check if current email/password are correct
-    const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;;
-    if (!user || password!=user.password) return false;
+    const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;
+    if (!user || password != user.password) return false;
 
     await user.update({ display_name: newDisplayName });
     return true;


### PR DESCRIPTION
Added a `Access-Control-Allow-Origin, no-cors` to the middleware errorHandler. This means that `failedToFetch` stuff in the frontend should now throw the proper error. To test, use the db page and run a POST command, and check its response.

![image](https://github.com/user-attachments/assets/7e7472af-34d8-4e4c-a1f5-c76f3987207b)
