### PR TITLE
Add script for resetting db

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "migrate:undo": "npx sequelize-cli db:migrate:undo",
     "seed:all": "npx sequelize-cli db:seed:all",
     "seed:undo": "npx sequelize-cli db:seed:undo",
-    "seed:undo:all": "npx sequelize-cli db:seed:undo:all"
+    "seed:undo:all": "npx sequelize-cli db:seed:undo:all",
+    "reset-database": "npx sequelize-cli db:migrate:undo:all & npx sequelize-cli db:migrate & npx sequelize-cli db:seed:all" 
   },
   "nodemonConfig": {
     "watch": "src/**",


### PR DESCRIPTION
The command `npm run reset-database` will reset the database back to the default data of
- 1 user
- 1 panel set
- 3 panels
- 3 hooks that lead to nowhere