### PR TITLE
Delete Image and update changePfp code

### DIFF
--- a/src/requestHandlers/image.ts
+++ b/src/requestHandlers/image.ts
@@ -33,7 +33,7 @@ const saveImage = async (req: Request, res: Response): Promise<Response> => {
 
     const validArgs = assertArgumentsString(id);
     if (!validArgs.success) return res.status(400).json(validArgs);
-    
+
     const response = await _saveImageController(id, buffer, mimetype);
     return sanitizeResponse(response, res);
 
@@ -153,7 +153,14 @@ const validateImageFile = (file: Express.Multer.File | null): boolean => {
     return mimetype.includes('image');
 };
 
+const _deleteImageController = (id: string) => {
+    try {
+        imageService.deleteImage(id);
+    } catch (error) {
+        return error;
+    }
+}
 
 export {
-    getAllImageUrlsByPanelSetId, _getAllImageUrlsByPanelSetIdController, getImageSigned,saveImage, _saveImageController, _getImageControllerSigned, validateImageFile
+    getAllImageUrlsByPanelSetId, _getAllImageUrlsByPanelSetIdController, getImageSigned,saveImage, _saveImageController, _getImageControllerSigned, validateImageFile, _deleteImageController
 };

--- a/src/requestHandlers/image.ts
+++ b/src/requestHandlers/image.ts
@@ -157,11 +157,12 @@ const validateImageFile = (file: Express.Multer.File | null): boolean => {
 const _deleteImageController = (id: string) => {
     try {
         imageService.deleteImage(id);
-    } catch (error) {
+    }
+    catch (error) {
         return error;
     }
-}
+};
 
 export {
-    getAllImageUrlsByPanelSetId, _getAllImageUrlsByPanelSetIdController, getImageSigned,saveImage, _saveImageController, _getImageControllerSigned, validateImageFile, _deleteImageController
+    getAllImageUrlsByPanelSetId, _getAllImageUrlsByPanelSetIdController, getImageSigned, saveImage, _saveImageController, _getImageControllerSigned, validateImageFile, _deleteImageController
 };

--- a/src/requestHandlers/image.ts
+++ b/src/requestHandlers/image.ts
@@ -156,7 +156,7 @@ const validateImageFile = (file: Express.Multer.File | null): boolean => {
 
 const _deleteImageController = (id: string) => {
     try {
-        imageService.deleteImage(id);
+        return imageService.deleteImage(id);
     }
     catch (error) {
         return error;

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -51,10 +51,10 @@ const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: 
 const deleteImage = async(id : string)=>{
 
     const params = {
-        Bucket:      process.env.BUCKET_NAME,
-        Key:         id
+        Bucket: process.env.BUCKET_NAME,
+        Key:    id
     };
-    
+
     await s3.send(new DeleteObjectCommand(params));
 
     return { id: id }; // return id to show valid deletion

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { s3 } from '../s3Init';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Sequelize } from 'sequelize';
@@ -47,6 +47,19 @@ const getAllImagesByPanelSetId = (sequelize: Sequelize) => async (panel_set_id: 
         order:      [ ['index', 'ASC'] ]
     });
 };
+
+const deleteImage = async(id : string)=>{
+
+    const params = {
+        Bucket:      process.env.BUCKET_NAME,
+        Key:         id
+    };
+    
+    await s3.send(new DeleteObjectCommand(params));
+
+    return { id: id }; // return id to show valid deletion
+};
+
 export {
-    saveImage, getImageSigned, getAllImagesByPanelSetId, getImage
+    saveImage, getImageSigned, getAllImagesByPanelSetId, getImage, deleteImage
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -144,7 +144,7 @@ const changePfp = (sequelize: Sequelize) => async (email: string, buffer: Buffer
 
     if(user.profile_picture) {
         const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length - 49)) as {id: string} | Error; // 49 is the length of the image id
-        if (!deleted || deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
+        if (deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
     }
 
     const id = user.id + Date.now();

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -142,8 +142,10 @@ const changePfp = (sequelize: Sequelize) => async (email: string, buffer: Buffer
     const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;
     if (!user) throw new Error(`No user found with email ${email}`);
 
-    const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length - 49)) as {id: string} | Error; // 49 is the length of the image id
-    if (!deleted || deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
+    if(user.profile_picture) {
+        const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length - 49)) as {id: string} | Error; // 49 is the length of the image id
+        if (!deleted || deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
+    }
 
     const id = user.id + Date.now();
     const PFP = await _saveImageController(id, buffer, mimetype) as {id: string} | Error;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -142,13 +142,13 @@ const changePfp = (sequelize: Sequelize) => async (email: string, buffer: Buffer
     const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;
     if (!user) throw new Error(`No user found with email ${email}`);
 
-    const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length-49)) as {id: string} | Error; //49 is the length of the image id
+    const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length - 49)) as {id: string} | Error; // 49 is the length of the image id
     if (!deleted || deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
 
-    const id = user.id+Date.now();
+    const id = user.id + Date.now();
     const PFP = await _saveImageController(id, buffer, mimetype) as {id: string} | Error;
     if (!PFP || PFP instanceof Error) throw new Error(`S3 Error ${PFP?.message}`);
-    
+
     const url = await getImage(id);
     await user.update({ profile_picture: url });
     return url;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,7 +1,7 @@
 import { Sequelize } from 'sequelize';
 import { ISession, IUser } from '../models';
 import bcrypt from 'bcrypt';
-import { _saveImageController } from '../requestHandlers/image';
+import { _deleteImageController, _saveImageController } from '../requestHandlers/image';
 import { getImage } from './imageService';
 
 /**
@@ -142,10 +142,15 @@ const changePfp = (sequelize: Sequelize) => async (email: string, buffer: Buffer
     const user = await sequelize.models.user.findOne({ where: { email } }) as IUser;
     if (!user) throw new Error(`No user found with email ${email}`);
 
-    const PFP = await _saveImageController(user.id, buffer, mimetype) as {id: string} | Error;
+    const deleted = await _deleteImageController(user.profile_picture.substring(user.profile_picture.length-49)) as {id: string} | Error; //49 is the length of the image id
+    if (!deleted || deleted instanceof Error) throw new Error(`S3 Error ${deleted?.message}`);
+
+    const id = user.id+Date.now();
+    const PFP = await _saveImageController(id, buffer, mimetype) as {id: string} | Error;
     if (!PFP || PFP instanceof Error) throw new Error(`S3 Error ${PFP?.message}`);
-    const url = await getImage(user.id);
-    if(!user.profile_picture) await user.update({ profile_picture: url });
+    
+    const url = await getImage(id);
+    await user.update({ profile_picture: url });
     return url;
 };
 


### PR DESCRIPTION
Added `deleteImage` and `_deleteImageController` to remove images from s3 given an image id. Added `deleteImage` to `changePfp` to remove old profile pictures when new ones are saved. The process of deleting and saving new images under a different link is faster than replacing an image at the same link so it works better for the purposes of the app. Test this PR by running the backend locally, changing your profile picture, seeing it in the `tmp` folder in the backend, then changing pfp again to see that the old file was deleted and a new one was added